### PR TITLE
fix(editor): 阻止右键菜单点击冒泡到文件行，避免删除时误打开文件

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - 规避会话备份/恢复时的 64 MiB runtime message 体积限制
 - 工具执行中点击停止后，工具卡片不再一直显示加载图标，「已取消」提示也移到工具卡片下方 (#21)
 - 询问用户/权限确认卡片的文本现在保留换行，多行时图标与首行对齐 (#23)
+- 文件编辑页窄屏布局下，右键删除文件时不再误把该文件重新打开 (#22)
 
 - Use the user-provided name for backup filenames
 - Avoid the 64 MiB runtime message limit on session backup and restore
 - Stop the tool card from spinning forever after cancelling a running tool, and move the "Cancelled" marker below the tool card (#21)
 - Preserve line breaks in ask-user and permission-prompt card text, and align the icon to the first line for multi-line text (#23)
+- File editor: deleting a file from the right-click menu no longer spuriously reopens it in the compact (narrow) layout (#22)
 
 ### 变更 / Changed
 

--- a/components/editor/FileTree.tsx
+++ b/components/editor/FileTree.tsx
@@ -103,6 +103,11 @@ function NodeRenderer({ node, style, dragHandle, tree }: NodeRendererProps<TreeN
   const allowNewFolder = (tree.props as any).allowNewFolder ?? true;
   const editStartRef = useRef<number>(0);
 
+  const runMenuAction = (action: () => void) => (e: React.MouseEvent) => {
+    e.stopPropagation();
+    action();
+  };
+
   const handleClick = (e: React.MouseEvent) => {
     if (node.isEditing) return; // Don't activate/toggle while inline-renaming
     if (node.isInternal) {
@@ -192,19 +197,19 @@ function NodeRenderer({ node, style, dragHandle, tree }: NodeRendererProps<TreeN
   if (node.isInternal) {
     menuItems = (
       <>
-        <ContextMenuItem onClick={() => (tree.props as any).onCreateFile?.(node.id)}>
+        <ContextMenuItem onClick={runMenuAction(() => (tree.props as any).onCreateFile?.(node.id))}>
           <FilePlus className="size-3.5 mr-2" /> {t('common.newFile')}
         </ContextMenuItem>
         {allowNewFolder && (
-          <ContextMenuItem onClick={() => (tree.props as any).onCreateFolder?.(node.id)}>
+          <ContextMenuItem onClick={runMenuAction(() => (tree.props as any).onCreateFolder?.(node.id))}>
             <FolderPlus className="size-3.5 mr-2" /> {t('common.newFolder')}
           </ContextMenuItem>
         )}
         <ContextMenuSeparator />
-        <ContextMenuItem onClick={() => node.edit()}>
+        <ContextMenuItem onClick={runMenuAction(() => node.edit())}>
           <Pencil className="size-3.5 mr-2" /> {t('common.rename')}
         </ContextMenuItem>
-        <ContextMenuItem onClick={() => tree.delete(node.id)} className="text-destructive focus:text-destructive">
+        <ContextMenuItem onClick={runMenuAction(() => tree.delete(node.id))} className="text-destructive focus:text-destructive">
           <Trash2 className="size-3.5 mr-2" /> {t('common.delete')}
         </ContextMenuItem>
       </>
@@ -212,10 +217,10 @@ function NodeRenderer({ node, style, dragHandle, tree }: NodeRendererProps<TreeN
   } else {
     menuItems = (
       <>
-        <ContextMenuItem onClick={() => node.edit()}>
+        <ContextMenuItem onClick={runMenuAction(() => node.edit())}>
           <Pencil className="size-3.5 mr-2" /> {t('common.rename')}
         </ContextMenuItem>
-        <ContextMenuItem onClick={() => tree.delete(node.id)} className="text-destructive focus:text-destructive">
+        <ContextMenuItem onClick={runMenuAction(() => tree.delete(node.id))} className="text-destructive focus:text-destructive">
           <Trash2 className="size-3.5 mr-2" /> {t('common.delete')}
         </ContextMenuItem>
       </>


### PR DESCRIPTION
<!--
Thanks for contributing to Cebian!

Before submitting, please confirm:
- [ ] `pnpm run check` passes locally
- [ ] Commit messages are concise and scoped
- [ ] I have read and agree to the [Cebian CLA](../CLA.md)
-->

## Summary

修复了编辑器中右键菜单的点击事件冒泡问题。

**问题原因**：在文件列表中右键打开上下文菜单后，点击菜单项（如"删除"）时，点击事件会冒泡到下层的文件行元素，触发文件打开操作，导致删除时误打开文件。

**修复方式**：在右键菜单的点击事件处理中调用 `stopPropagation()`，阻止事件冒泡至父级文件行元素。

## Related Issues

Closes #22

## Testing

1. 在编辑器文件列表中，对某个文件右键打开菜单
2. 点击"删除"选项
3. 验证文件被正常删除，且不会同时触发文件打开操作

## Checklist

- [x] `pnpm run check` passes locally
- [x] I have read and agree to the [Cebian CLA](../CLA.md)
