### PR TITLE
feat: support per-store publishing in store-publish.yml

### DIFF
--- a/.github/workflows/store-publish.yml
+++ b/.github/workflows/store-publish.yml
@@ -1,11 +1,12 @@
 name: Publish to Stores
 
-# 监听 GitHub Release 发布事件:你在仓库点 "Publish release" 后自动把扩展提交到
+# 监听 GitHub Release 发布事件:你在仓库点 "Publish release" 后自动把扩展同时提交到
 # Chrome Web Store 与 Edge Add-ons。复用该 Release 上已验证的 chrome zip 资产,
 # 绝不重新构建,确保上架的字节与你 smoke-test 过的完全一致。
 #
 # 也支持手动触发(workflow_dispatch):指定一个已发布的 tag 重新推商店,用于
 # token 失效修复后重推、或某个商店单独补推等场景。手动触发同样要过审批门。
+# 通过 target 参数可选择只推 chrome、只推 edge、或同时推两个商店(默认)。
 #
 # 安全设计:
 #   - 第三方 action 全部 pin 到完整 commit SHA(防供应链投毒)。
@@ -22,6 +23,15 @@ on:
         description: '已发布的 Release tag(例 v1.3.2),从其资产取 chrome zip 重新推商店'
         required: true
         type: string
+      target:
+        description: '目标商店:both = Chrome + Edge,chrome = 仅 Chrome,edge = 仅 Edge'
+        required: false
+        type: choice
+        default: both
+        options:
+          - both
+          - chrome
+          - edge
 
 permissions:
   contents: read
@@ -72,6 +82,8 @@ jobs:
     name: Publish to Chrome Web Store
     runs-on: ubuntu-latest
     needs: fetch
+    # release 触发始终发布;手动触发仅当 target 为 chrome 或 both 时发布
+    if: ${{ github.event_name == 'release' || github.event.inputs.target == 'both' || github.event.inputs.target == 'chrome' }}
     environment: store-publish # 审批门 + 商店密钥(Chrome 与 Edge 共用同一环境)
     steps:
       - name: Download chrome zip
@@ -95,6 +107,8 @@ jobs:
     name: Publish to Edge Add-ons
     runs-on: ubuntu-latest
     needs: fetch
+    # release 触发始终发布;手动触发仅当 target 为 edge 或 both 时发布
+    if: ${{ github.event_name == 'release' || github.event.inputs.target == 'both' || github.event.inputs.target == 'edge' }}
     environment: store-publish # 审批门 + 商店密钥(Chrome 与 Edge 共用同一环境)
     steps:
       - name: Download chrome zip


### PR DESCRIPTION
<!--
Thanks for contributing to Cebian!

⚠️ 提交前必读 / READ BEFORE OPENING:
本项目要求外部贡献者的 PR 必须关联一个经过维护者批准的 issue（打有 `ready-to-implement`
标签）。不符合此要求的 PR 将被机器人自动关闭（维护者和协作者的 PR 不受此限制）。请先
在对应 issue 里讨论你的实现方案，等维护者回复 `/ready`，该 issue 打上标签后，再提交 PR，并在描述中写明 `Closes #<issue 编号>`。

For external contributors, every PR must reference a maintainer-approved issue (carrying
the `ready-to-implement` label). PRs that don't will be auto-closed by a bot (PRs from
maintainers and collaborators are exempt). Please discuss your approach in the issue
first, wait for the maintainer to reply `/ready`,
then open the PR with `Closes #<issue number>` in the description.

Before submitting, please confirm:
- [ ] `pnpm run check` passes locally
- [ ] Commit messages are concise and scoped
- [ ] I have read and agree to the [Cebian CLA](../CLA.md)
-->

## Summary

<!-- What does this PR change, and why? -->

## Related Issues

<!-- Closes #NNN / Fixes #NNN / Resolves #NNN -->
<!-- 必填项：本 PR 必须通过 `Closes #<issue 编号>` 关联一个带 `ready-to-implement` 标签的 issue，否则会被自动关闭。仅用 `#NNN` 提及而不加关键字，不视为有效关联。 -->
<!-- Required: this PR must use `Closes #<issue number>` to link an issue labeled `ready-to-implement`, or it will be auto-closed. A plain `#NNN` mention does not count. -->

## Testing

<!-- How did you verify the change? What should reviewers click/check? -->

## Checklist

- [ ] `pnpm run check` passes locally
- [ ] I have read and agree to the [Cebian CLA](../CLA.md)
