### PR TITLE
fix: skill import rejects valid vfs.read/vfs.write/bgFetch permissions

### DIFF
--- a/lib/ai-config/skill-transfer.ts
+++ b/lib/ai-config/skill-transfer.ts
@@ -149,6 +149,8 @@ function assertSkillName(name: string): void {
 function assertPermissionsAllowed(permissions: string[]): void {
   for (const p of permissions) {
     if (p === 'page.executeJs') continue;
+    if (p === 'vfs.read' || p === 'vfs.write') continue;
+    if (p === 'bgFetch' || p.startsWith('bgFetch:')) continue;
     const m = /^chrome\.([a-zA-Z][a-zA-Z0-9]*)$/.exec(p);
     // hasOwnProperty guard: avoid accepting inherited names like
     // "chrome.constructor" or "chrome.toString" as legitimate permissions.


### PR DESCRIPTION
## Bug Description / Bug 描述

Closes #37 

When importing a skill package (`.cebian-skill.zip`) whose `SKILL.md` declares `vfs.read`, `vfs.write`, `bgFetch`, or `bgFetch:<match-pattern>` in `metadata.permissions`, the import is rejected with an `unsupportedPermission` error.

导入一个在 SKILL.md 的 metadata.permissions 中声明了 vfs.read / vfs.write / bgFetch / bgFetch:<match-pattern> 的 skill 包时，导入被 `unsupportedPermission` 错误拒绝。

## Root Cause / 根因

The `assertPermissionsAllowed` validator in `skill-transfer.ts` only accepts `page.executeJs` and `chrome.<ns>` permissions. It was not updated when `vfs.read`, `vfs.write`, `bgFetch`, and `bgFetch:<match-pattern>` were added to the runtime sandbox permission system.

`skill-transfer.ts` 的权限校验函数 `assertPermissionsAllowed` 只放行 `page.executeJs` 和 `chrome.<ns>`，在运行时沙箱新增 `vfs`/`bgFetch` 权限时未同步更新白名单。

## Scenario / 复现场景

1. A skill's `SKILL.md` has:
   ```yaml
   metadata:
     permissions:
       - vfs.read
   ```
2. Export the skill as `.cebian-skill.zip`
3. Try to import it via Settings → Skills → Import
4. The import preview dialog shows: `unsupportedPermission: vfs.read` and refuses to proceed.

## Fix / 修复

Added explicit allow entries for `vfs.read`, `vfs.write`, `bgFetch`, and `bgFetch:<pattern>` in the `assertPermissionsAllowed` function, before the `chrome.<ns>` check.

在 `assertPermissionsAllowed` 函数中，在 `chrome.<ns>` 检查之前补充了对 `vfs.read`、`vfs.write`、`bgFetch` 和 `bgFetch:<pattern>` 的放行判断。

## Change / 改动

- `lib/ai-config/skill-transfer.ts`: 2 lines added in `assertPermissionsAllowed()`
```typescript
if (p === 'vfs.read' || p === 'vfs.write') continue;
if (p === 'bgFetch' || p.startsWith('bgFetch:')) continue;
```

今天使用过程中遇到的：
<img width="1112" height="559" alt="1" src="https://github.com/user-attachments/assets/1612a985-aba2-4968-b148-4fb54749bd1a" />
<img width="1522" height="838" alt="2" src="https://github.com/user-attachments/assets/2fa51239-b891-46f8-b76e-152d5cc3bebf" />

修复之后就可以成功导入skill了 
<img width="731" height="312" alt="image" src="https://github.com/user-attachments/assets/4878219d-e17d-4be5-8c5a-cc774fc8744d" />

<br>

## Suggestion / 维护建议
This bug stems from the permission allow-list being maintained in two separate places — the runtime sandbox (``entrypoints/sandbox/main.ts`` ,``lib/tools/sandbox-rpc.ts`` ) and the import validator (``assertPermissionsAllowed`` ). When new permissions are added to one, it's easy to forget the other.

It might be worth considering extracting the valid-permission check into a single shared source of truth (e.g.``lib/tools/skill-permissions.ts`` ), so that both the runtime and the import path call the same function. A comment on``assertPermissionsAllowed`` reminding future contributors to sync both sides would also help in the meantime.

Thanks for the great project, and I hope this helps!

这个 bug 的根因在于权限白名单在两个地方各自维护——运行时沙箱（``entrypoints/sandbox/main.ts`` 、``lib/tools/sandbox-rpc.ts`` ）和导入校验（``assertPermissionsAllowed`` ）。新增权限时容易遗漏同步。

可以考虑把有效的权限判断抽取到一个共享的单一事实来源（例如``lib/tools/skill-permissions.ts`` ），让运行时和导入路径都调用同一个函数。作为过渡，在``assertPermissionsAllowed`` 上加一段注释提醒未来的贡献者同步两端也会有帮助。

感谢这个很棒的项目，希望这个 PR 能有所帮助！