### PR TITLE
Feat/ask user form

### DIFF
--- a/components/chat/FormBlock.tsx
+++ b/components/chat/FormBlock.tsx
@@ -1,0 +1,311 @@
+import { useState, useCallback } from 'react';
+import { ClipboardList, Send } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import type { AskUserQuestion, AskUserAnswer, AskUserResponse } from '@/lib/tools/ask-user';
+import { t } from '@/lib/i18n';
+
+// ─── Types ───
+
+interface FormBlockProps {
+  request: {
+    title?: string;
+    description?: string;
+    submit_label?: string;
+    questions: AskUserQuestion[];
+  };
+  answered: boolean;
+  onResolve?: (response: AskUserResponse) => void;
+}
+
+// ─── Field-level value type ───
+
+type FieldValue = string | string[] | null;
+
+// ─── Component ───
+
+export function FormBlock({ request, answered, onResolve }: FormBlockProps) {
+  const safeFields = Array.isArray(request?.questions)
+    ? request.questions.filter((f): f is AskUserQuestion =>
+        !!f && typeof f === 'object' && typeof f.id === 'string' && typeof f.question === 'string'
+      )
+    : [];
+  if (safeFields.length === 0) return null;
+
+  const { title, description, submit_label } = request;
+  const fields = safeFields;
+
+  const [values, setValues] = useState<Record<string, FieldValue>>(() => {
+    const init: Record<string, FieldValue> = {};
+    for (const field of fields) {
+      if (field.type === 'multi_select' || field.multiple) {
+        init[field.id] = [];
+      } else {
+        init[field.id] = null;
+      }
+    }
+    return init;
+  });
+
+  const setFieldValue = useCallback((fieldId: string, value: FieldValue) => {
+    setValues(prev => ({ ...prev, [fieldId]: value }));
+  }, []);
+
+  const toggleMultiSelect = useCallback((fieldId: string, value: string) => {
+    setValues(prev => {
+      const current = (prev[fieldId] as string[]) || [];
+      const next = current.includes(value)
+        ? current.filter(v => v !== value)
+        : [...current, value];
+      return { ...prev, [fieldId]: next };
+    });
+  }, []);
+
+  const errors = validateForm(fields, values);
+  const hasErrors = Object.values(errors).some(e => !!e);
+
+  const handleSubmit = () => {
+    if (hasErrors || !onResolve) return;
+    const answers: Record<string, AskUserAnswer> = {};
+    for (const field of fields) {
+      const val = values[field.id];
+      if (val == null || val === '' || (Array.isArray(val) && val.length === 0)) {
+        answers[field.id] = { value: null };
+      } else {
+        answers[field.id] = { value: val };
+      }
+    }
+    onResolve({ answers });
+  };
+
+  return (
+    <div className={`relative mt-3 p-3.5 border border-primary/20 bg-primary/5 rounded-lg ${answered ? 'opacity-60' : ''}`}>
+      <div className="flex items-start gap-2 text-primary font-medium text-[0.85rem] mb-3">
+        <ClipboardList className="size-4.5 shrink-0 mt-0.5" />
+        <div>
+          <span className="whitespace-pre-wrap">{title || t('chat.form.title')}</span>
+          {description && (
+            <p className="text-[0.75rem] text-muted-foreground font-normal mt-0.5 whitespace-pre-wrap">
+              {description}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-3.5">
+        {fields.map(field => (
+          <FormFieldWidget
+            key={field.id}
+            field={field}
+            value={values[field.id]}
+            error={errors[field.id]}
+            disabled={answered || !onResolve}
+            onChange={val => setFieldValue(field.id, val)}
+            onToggleMulti={val => toggleMultiSelect(field.id, val)}
+          />
+        ))}
+      </div>
+
+      {onResolve && !answered && (
+        <div className="flex justify-end mt-4">
+          <Button
+            size="sm"
+            disabled={hasErrors}
+            onClick={handleSubmit}
+          >
+            <Send className="size-3.5 mr-1.5" />
+            {submit_label || t('chat.form.submit')}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Field widget ───
+
+function FormFieldWidget({
+  field,
+  value,
+  error,
+  disabled,
+  onChange,
+  onToggleMulti,
+}: {
+  field: AskUserQuestion;
+  value: FieldValue;
+  error?: string;
+  disabled: boolean;
+  onChange: (val: FieldValue) => void;
+  onToggleMulti: (val: string) => void;
+}) {
+  const type = field.type ?? 'text';
+  const isMulti = type === 'multi_select' || field.multiple;
+  const options = field.options?.filter(
+    (o): o is NonNullable<typeof field.options>[number] => !!o && typeof o.label === 'string'
+  ) ?? [];
+
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-xs font-medium flex items-center gap-1">
+        {field.question}
+        {field.required && <span className="text-destructive">*</span>}
+      </Label>
+      {field.message && (
+        <p className="text-[0.65rem] text-muted-foreground whitespace-pre-wrap">{field.message}</p>
+      )}
+
+      {/* Text input */}
+      {(type === 'text') && (
+        <Input
+          value={(value as string) ?? ''}
+          placeholder={field.placeholder ?? ''}
+          disabled={disabled}
+          onChange={e => onChange(e.target.value)}
+          className="h-8 text-xs"
+        />
+      )}
+
+      {/* Textarea */}
+      {type === 'textarea' && (
+        <Textarea
+          value={(value as string) ?? ''}
+          placeholder={field.placeholder ?? ''}
+          disabled={disabled}
+          rows={3}
+          onChange={e => onChange(e.target.value)}
+          className="text-xs resize-y"
+        />
+      )}
+
+      {/* Dropdown */}
+      {type === 'dropdown' && (
+        <select
+          value={(value as string) ?? ''}
+          disabled={disabled}
+          onChange={e => onChange(e.target.value)}
+          className="w-full h-8 rounded-md border border-input bg-background px-2.5 text-xs focus:outline-none focus:ring-1 focus:ring-primary/30"
+        >
+          <option value="">{field.placeholder || t('chat.form.selectPlaceholder')}</option>
+          {options.map(opt => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      )}
+
+      {/* Single select (radio) */}
+      {type === 'single_select' && (
+        <div className="space-y-1.5">
+          {options.map(opt => (
+            <label
+              key={opt.value}
+              className={`flex items-center gap-2 px-2.5 py-1.5 rounded-md border cursor-pointer text-xs transition-colors ${
+                disabled ? 'opacity-60 cursor-default' : 'hover:bg-accent/50'
+              } ${
+                value === opt.value ? 'border-primary bg-primary/10' : 'border-border'
+              }`}
+            >
+              <input
+                type="radio"
+                name={field.id}
+                value={opt.value}
+                checked={value === opt.value}
+                disabled={disabled}
+                onChange={e => onChange(e.target.value)}
+                className="size-3.5 accent-primary"
+              />
+              <span className="flex-1">{opt.label}</span>
+              {opt.recommended && (
+                <span className="text-[0.6rem] text-primary/70 font-medium px-1 py-0.5 rounded bg-primary/10">
+                  {t('chat.form.recommended')}
+                </span>
+              )}
+            </label>
+          ))}
+        </div>
+      )}
+
+      {/* Multi select (checkbox) */}
+      {isMulti && options.length > 0 && (
+        <div className="space-y-1.5">
+          <div className="space-y-1">
+            {options.map(opt => (
+              <label
+                key={opt.value}
+                className={`flex items-center gap-2 px-2.5 py-1.5 rounded-md border cursor-pointer text-xs transition-colors ${
+                  disabled ? 'opacity-60 cursor-default' : 'hover:bg-accent/50'
+                } ${
+                  Array.isArray(value) && value.includes(opt.value) ? 'border-primary bg-primary/10' : 'border-border'
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  value={opt.value}
+                  checked={Array.isArray(value) && value.includes(opt.value)}
+                  disabled={disabled}
+                  onChange={() => onToggleMulti(opt.value)}
+                  className="size-3.5 accent-primary rounded"
+                />
+                <span className="flex-1">{opt.label}</span>
+                {opt.recommended && (
+                  <span className="text-[0.6rem] text-primary/70 font-medium px-1 py-0.5 rounded bg-primary/10">
+                    {t('chat.form.recommended')}
+                  </span>
+                )}
+              </label>
+            ))}
+          </div>
+          {(field.min_select || field.max_select) && (
+            <p className="text-[0.65rem] text-muted-foreground">
+              {field.min_select && field.max_select
+                ? t('chat.form.selectRange', [String(field.min_select), String(field.max_select)])
+                : field.min_select
+                  ? t('chat.form.minSelect', [String(field.min_select)])
+                  : field.max_select
+                    ? t('chat.form.maxSelect', [String(field.max_select)])
+                    : null}
+            </p>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <p className="text-[0.65rem] text-destructive mt-1">{error}</p>
+      )}
+    </div>
+  );
+}
+
+// ─── Validation ───
+
+function validateForm(
+  fields: AskUserQuestion[],
+  values: Record<string, FieldValue>,
+): Record<string, string> {
+  const errors: Record<string, string> = {};
+  for (const field of fields) {
+    const val = values[field.id];
+    if (field.required) {
+      if (val == null || val === '' || (Array.isArray(val) && val.length === 0)) {
+        errors[field.id] = t('chat.form.required');
+        continue;
+      }
+    }
+    if (val == null || val === '' || (Array.isArray(val) && val.length === 0)) continue;
+
+    const isMulti = field.type === 'multi_select' || field.multiple;
+    if (isMulti && Array.isArray(val)) {
+      if (field.min_select != null && val.length < field.min_select) {
+        errors[field.id] = t('chat.form.minSelect', [String(field.min_select)]);
+      }
+      if (field.max_select != null && val.length > field.max_select) {
+        errors[field.id] = t('chat.form.maxSelect', [String(field.max_select)]);
+      }
+    }
+  }
+  return errors;
+}

--- a/components/chat/Message.tsx
+++ b/components/chat/Message.tsx
@@ -11,6 +11,7 @@ import { t } from '@/lib/i18n';
 import { describePermission } from '@/lib/agent/tool-permissions';
 import { downloadFile, formatDuration, formatCharCount } from '@/lib/utils';
 import { FormBlock } from '@/components/chat/FormBlock';
+import { WizardBlock } from '@/components/chat/WizardBlock';
 import { normalizeRequest } from '@/lib/tools/ask-user';
 import type { Message } from '@earendil-works/pi-ai';
 
@@ -305,12 +306,23 @@ export function AskUserBlock({
   const normalized = normalizeRequest(request as Record<string, unknown>);
   const fields = normalized.questions;
 
-  // Mode A: compact single-question mode (no title, single field)
-  if (fields.length === 1 && !request.title && !request.description) {
+  // Mode A: compact single-question mode (no title, single field, no pagination)
+  if (fields.length === 1 && !normalized.title && !normalized.description && !normalized.pagination) {
     return (
       <AskUserCompactBlock
         field={fields[0]}
         answered={answered}
+        onResolve={onResolve}
+      />
+    );
+  }
+
+  // Mode C: wizard mode (pagination configured)
+  if (normalized.pagination?.type === 'wizard') {
+    return (
+      <WizardBlock
+        request={normalized}
+        answered={!!answered}
         onResolve={onResolve}
       />
     );

--- a/components/chat/Message.tsx
+++ b/components/chat/Message.tsx
@@ -10,6 +10,8 @@ import { RECORDING_MIME } from '@/lib/agent/attachments';
 import { t } from '@/lib/i18n';
 import { describePermission } from '@/lib/agent/tool-permissions';
 import { downloadFile, formatDuration, formatCharCount } from '@/lib/utils';
+import { FormBlock } from '@/components/chat/FormBlock';
+import { normalizeRequest } from '@/lib/tools/ask-user';
 import type { Message } from '@earendil-works/pi-ai';
 
 /* ─── User Message ─── */
@@ -290,25 +292,66 @@ function PromptOptionButton({
 
 /* ─── Ask User Block (interactive tool UI) ─── */
 export function AskUserBlock({
-  question,
-  options,
-  allowFreeText = true,
+  request,
   answered,
-  onSelect,
+  onResolve,
 }: {
-  question: string;
-  options?: { label: string; description?: string }[];
-  allowFreeText?: boolean;
+  request: import('@/lib/tools/ask-user').AskUserRequest;
   answered?: boolean;
-  onSelect?: (text: string) => void;
+  onResolve?: (response: import('@/lib/tools/ask-user').AskUserResponse) => void;
+}) {
+  // Normalize: the raw tool arguments may be in legacy format ({ question, options })
+  // rather than the new internal format ({ questions: [...] }).
+  const normalized = normalizeRequest(request as Record<string, unknown>);
+  const fields = normalized.questions;
+
+  // Mode A: compact single-question mode (no title, single field)
+  if (fields.length === 1 && !request.title && !request.description) {
+    return (
+      <AskUserCompactBlock
+        field={fields[0]}
+        answered={answered}
+        onResolve={onResolve}
+      />
+    );
+  }
+
+  // Mode B: multi-field form
+  return (
+    <FormBlock
+      request={normalized}
+      answered={!!answered}
+      onResolve={onResolve}
+    />
+  );
+}
+
+/* ─── Ask User Compact Block (mode A: single question) ─── */
+
+function AskUserCompactBlock({
+  field,
+  answered,
+  onResolve,
+}: {
+  field: import('@/lib/tools/ask-user').AskUserQuestion;
+  answered?: boolean;
+  onResolve?: (response: import('@/lib/tools/ask-user').AskUserResponse) => void;
 }) {
   const [freeText, setFreeText] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const question = field.question;
+  const options = field.options;
+  const allowFreeText = field.allow_free_text ?? (options == null || options.length === 0);
+  const type = field.type ?? (options && options.length > 0 ? 'single_select' : 'text');
 
   const handleFreeTextSubmit = () => {
     if (!freeText.trim()) return;
-    onSelect?.(freeText.trim());
+    onResolve?.({ answers: { [field.id]: { value: freeText.trim() } } });
     setFreeText('');
+  };
+
+  const handleOptionSelect = (opt: { label: string; value: string }) => {
+    onResolve?.({ answers: { [field.id]: { value: opt.value } } });
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
@@ -327,11 +370,9 @@ export function AskUserBlock({
 
       {/* Option buttons */}
       {(() => {
-        // Defensive: model may stream partial JSON or return wrong type (string / object).
-        // Only render when options is a real array of objects with a label.
         const safeOptions = Array.isArray(options)
-          ? options.filter((o): o is { label: string; description?: string } =>
-              !!o && typeof o === 'object' && typeof (o as { label?: unknown }).label === 'string'
+          ? options.filter((o): o is NonNullable<typeof options>[number] =>
+              !!o && typeof o === 'object' && typeof o.label === 'string'
             )
           : [];
         if (safeOptions.length === 0) return null;
@@ -339,11 +380,11 @@ export function AskUserBlock({
           <div className="flex flex-wrap gap-2 mt-2.5">
             {safeOptions.map((opt, i) => (
               <PromptOptionButton
-                key={`${i}-${opt.label}`}
+                key={`${i}-${opt.value ?? opt.label}`}
                 label={opt.label}
                 description={opt.description}
-                disabled={!onSelect}
-                onClick={onSelect ? () => onSelect(opt.label) : undefined}
+                disabled={!onResolve}
+                onClick={onResolve ? () => handleOptionSelect(opt) : undefined}
               />
             ))}
           </div>
@@ -351,14 +392,14 @@ export function AskUserBlock({
       })()}
 
       {/* Free text input */}
-      {allowFreeText && onSelect && (
+      {allowFreeText && onResolve && (
         <div className="flex items-end gap-1.5 mt-2.5">
           <textarea
             ref={textareaRef}
             value={freeText}
             onChange={(e) => setFreeText(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder={t('chat.askUser.placeholder')}
+            placeholder={field.placeholder || t('chat.askUser.placeholder')}
             rows={1}
             className="flex-1 resize-none bg-background border border-border rounded-md px-2.5 py-1.5 text-xs leading-relaxed placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-primary/30"
           />

--- a/components/chat/WizardBlock.tsx
+++ b/components/chat/WizardBlock.tsx
@@ -1,0 +1,493 @@
+import { useState, useCallback, useMemo } from 'react';
+import { ClipboardList, ChevronLeft, ChevronRight, Send, CheckCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import type { AskUserQuestion, AskUserAnswer, AskUserResponse } from '@/lib/tools/ask-user';
+import { t } from '@/lib/i18n';
+
+// ─── Types ───
+
+interface WizardBlockProps {
+  request: {
+    title?: string;
+    description?: string;
+    submit_label?: string;
+    pagination?: {
+      type: 'wizard';
+      show_progress?: boolean;
+      allow_skip?: boolean;
+      allow_review?: boolean;
+    };
+    questions: AskUserQuestion[];
+  };
+  answered: boolean;
+  onResolve?: (response: AskUserResponse) => void;
+}
+
+// ─── Step grouping ───
+
+interface WizardStep {
+  index: number;     // 0-based
+  number: number;    // 1-based display
+  title: string;
+  fields: AskUserQuestion[];
+}
+
+function groupSteps(questions: AskUserQuestion[]): WizardStep[] {
+  const stepMap = new Map<number, AskUserQuestion[]>();
+  for (const q of questions) {
+    const step = q.step ?? 1;
+    if (!stepMap.has(step)) stepMap.set(step, []);
+    stepMap.get(step)!.push(q);
+  }
+  // Sort by step number, collect titles (use first field's step_title or default)
+  const sorted = Array.from(stepMap.entries()).sort((a, b) => a[0] - b[0]);
+  return sorted.map(([stepNum, fields], idx) => {
+    const firstTitle = fields.find(f => f.step_title)?.step_title;
+    return {
+      index: idx,
+      number: stepNum,
+      title: firstTitle || `${t('chat.wizard.step')} ${stepNum}`,
+      fields,
+    };
+  });
+}
+
+// ─── Field value type ───
+
+type FieldValue = string | string[] | null;
+
+// ─── Component ───
+
+export function WizardBlock({ request, answered, onResolve }: WizardBlockProps) {
+  const { title, description, submit_label, pagination } = request;
+  const questions = request.questions;
+  const showProgress = pagination?.show_progress !== false;
+  const allowSkip = pagination?.allow_skip === true;
+  const allowReview = pagination?.allow_review !== false;
+
+  // Group into steps
+  const steps = useMemo(() => groupSteps(questions), [questions]);
+
+  // Add review step if enabled
+  const allSteps: (WizardStep | 'review')[] = useMemo(
+    () => (allowReview ? [...steps, 'review' as const] : steps),
+    [steps, allowReview],
+  );
+
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const [values, setValues] = useState<Record<string, FieldValue>>(() => {
+    const init: Record<string, FieldValue> = {};
+    for (const q of questions) {
+      const isMulti = q.type === 'multi_select' || q.multiple;
+      init[q.id] = isMulti ? [] : null;
+    }
+    return init;
+  });
+
+  const setFieldValue = useCallback((id: string, val: FieldValue) => {
+    setValues(prev => ({ ...prev, [id]: val }));
+  }, []);
+
+  const toggleMultiSelect = useCallback((id: string, val: string) => {
+    setValues(prev => {
+      const cur = (prev[id] as string[]) || [];
+      const next = cur.includes(val) ? cur.filter(v => v !== val) : [...cur, val];
+      return { ...prev, [id]: next };
+    });
+  }, []);
+
+  const isReviewStep = allSteps[currentStepIndex] === 'review';
+  const currentStep = allSteps[currentStepIndex];
+  const currentFields = isReviewStep ? [] : (currentStep as WizardStep).fields;
+
+  // Validate current step
+  const stepErrors = useMemo(() => {
+    const errs: Record<string, string> = {};
+    for (const field of currentFields) {
+      const val = values[field.id];
+      if (field.required) {
+        if (val == null || val === '' || (Array.isArray(val) && val.length === 0)) {
+          errs[field.id] = t('chat.form.required');
+          continue;
+        }
+      }
+      if (val == null || val === '' || (Array.isArray(val) && val.length === 0)) continue;
+      const isMulti = field.type === 'multi_select' || field.multiple;
+      if (isMulti && Array.isArray(val)) {
+        if (field.min_select != null && val.length < field.min_select) {
+          errs[field.id] = t('chat.form.minSelect', [String(field.min_select)]);
+        }
+        if (field.max_select != null && val.length > field.max_select) {
+          errs[field.id] = t('chat.form.maxSelect', [String(field.max_select)]);
+        }
+      }
+    }
+    return errs;
+  }, [currentFields, values]);
+
+  const hasErrors = Object.values(stepErrors).some(e => !!e);
+  const isFirstStep = currentStepIndex === 0;
+  const isLastStep = currentStepIndex === allSteps.length - 1;
+
+  const canAdvance = isReviewStep || (allowSkip && currentFields.every(f => !f.required)) || (!hasErrors && currentFields.length > 0);
+
+  const handleNext = () => {
+    if (isLastStep) {
+      handleSubmit();
+    } else {
+      setCurrentStepIndex(prev => prev + 1);
+    }
+  };
+
+  const handlePrev = () => {
+    if (!isFirstStep) {
+      setCurrentStepIndex(prev => prev - 1);
+    }
+  };
+
+  const handleStepClick = (idx: number) => {
+    // Allow clicking back to any completed step or the next uncompleted one
+    if (idx <= currentStepIndex) {
+      setCurrentStepIndex(idx);
+    }
+  };
+
+  const handleSubmit = () => {
+    if (!onResolve) return;
+    const answers: Record<string, AskUserAnswer> = {};
+    for (const q of questions) {
+      const val = values[q.id];
+      if (val == null || val === '' || (Array.isArray(val) && val.length === 0)) {
+        answers[q.id] = { value: null };
+      } else {
+        answers[q.id] = { value: val };
+      }
+    }
+    onResolve({ answers });
+  };
+
+  if (answered) {
+    return (
+      <div className="relative mt-3 p-3.5 border border-primary/20 bg-primary/5 rounded-lg opacity-60">
+        <div className="flex items-start gap-2 text-primary font-medium text-[0.85rem]">
+          <CheckCircle className="size-4.5 shrink-0 mt-0.5" />
+          <span>{title || t('chat.form.title')}</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative mt-3 p-3.5 border border-primary/20 bg-primary/5 rounded-lg">
+      {/* Header */}
+      <div className="flex items-start gap-2 text-primary font-medium text-[0.85rem] mb-3">
+        <ClipboardList className="size-4.5 shrink-0 mt-0.5" />
+        <div className="flex-1">
+          <span className="whitespace-pre-wrap">{title || t('chat.form.title')}</span>
+          {description && (
+            <p className="text-[0.75rem] text-muted-foreground font-normal mt-0.5 whitespace-pre-wrap">
+              {description}
+            </p>
+          )}
+        </div>
+        {/* Step counter */}
+        <span className="text-[0.7rem] text-muted-foreground shrink-0 mt-0.5">
+          {t('chat.wizard.stepOf', [String(currentStepIndex + 1), String(allSteps.length)])}
+        </span>
+      </div>
+
+      {/* Progress indicator */}
+      {showProgress && allSteps.length > 1 && (
+        <div className="flex items-center gap-1 mb-3">
+          {allSteps.map((step, idx) => {
+            const isReview = step === 'review';
+            const stepData = isReview ? null : step as WizardStep;
+            const isActive = idx === currentStepIndex;
+            const isDone = idx < currentStepIndex;
+
+            return (
+              <div key={idx} className="flex items-center gap-1 flex-1 min-w-0">
+                {/* Connector before (except first) */}
+                {idx > 0 && (
+                  <div className={`h-0.5 flex-1 rounded-full ${isDone ? 'bg-primary' : 'bg-border'}`} />
+                )}
+                {/* Step dot + label */}
+                <button
+                  type="button"
+                  disabled={idx > currentStepIndex}
+                  onClick={() => handleStepClick(idx)}
+                  className={`flex items-center gap-1 px-1.5 py-0.5 rounded text-[0.65rem] font-medium transition-colors shrink-0 ${
+                    isActive
+                      ? 'bg-primary text-primary-foreground'
+                      : isDone
+                        ? 'text-primary cursor-pointer hover:bg-primary/10'
+                        : 'text-muted-foreground cursor-default'
+                  }`}
+                >
+                  {isDone ? (
+                    <CheckCircle className="size-3" />
+                  ) : (
+                    <span className="size-3 rounded-full border border-current flex items-center justify-center text-[0.5rem] leading-none">
+                      {isReview ? 'R' : (stepData?.number ?? idx + 1)}
+                    </span>
+                  )}
+                  <span className="truncate max-w-[60px]">
+                    {isReview ? t('chat.wizard.review') : (stepData?.title ?? '')}
+                  </span>
+                </button>
+                {/* Connector after (except last) */}
+                {idx < allSteps.length - 1 && (
+                  <div className={`h-0.5 flex-1 rounded-full ${isDone ? 'bg-primary' : 'bg-border'}`} />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Current step title */}
+      {!isReviewStep && currentStep && (
+        <p className="text-[0.8rem] font-medium text-foreground mb-3">
+          {(currentStep as WizardStep).title}
+        </p>
+      )}
+
+      {/* Review step */}
+      {isReviewStep && (
+        <div className="space-y-2 mb-3">
+          <p className="text-[0.8rem] font-medium text-foreground">{t('chat.wizard.review')}</p>
+          <p className="text-[0.7rem] text-muted-foreground mb-2">{t('chat.wizard.reviewDesc')}</p>
+          {steps.map(step => (
+            <div key={step.number} className="rounded border border-border p-2.5">
+              <p className="text-[0.7rem] font-medium text-muted-foreground mb-1.5">{step.title}</p>
+              {step.fields.map(field => {
+                const val = values[field.id];
+                const display = val == null || val === '' || (Array.isArray(val) && val.length === 0)
+                  ? <span className="text-muted-foreground italic">{t('chat.wizard.notFilled')}</span>
+                  : Array.isArray(val)
+                    ? val.join(', ')
+                    : String(val);
+                return (
+                  <div key={field.id} className="flex gap-2 text-[0.75rem] py-0.5">
+                    <span className="text-muted-foreground shrink-0">{field.question}:</span>
+                    <span className="text-foreground">{display}</span>
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Fields for current step */}
+      {!isReviewStep && currentFields.length > 0 && (
+        <div className="space-y-3.5 mb-3">
+          {currentFields.map(field => (
+            <WizardFieldWidget
+              key={field.id}
+              field={field}
+              value={values[field.id]}
+              error={stepErrors[field.id]}
+              disabled={!onResolve}
+              onChange={val => setFieldValue(field.id, val)}
+              onToggleMulti={val => toggleMultiSelect(field.id, val)}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Navigation */}
+      {onResolve && (
+        <div className="flex justify-between items-center mt-3 pt-3 border-t border-border/50">
+          <div>
+            {!isFirstStep && (
+              <Button variant="ghost" size="sm" onClick={handlePrev}>
+                <ChevronLeft className="size-3.5 mr-1" />
+                {t('chat.wizard.prev')}
+              </Button>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            {allowSkip && !isReviewStep && !isLastStep && (
+              <Button variant="ghost" size="sm" onClick={handleNext}>
+                {t('chat.wizard.skip')}
+              </Button>
+            )}
+            <Button size="sm" disabled={!canAdvance && !isReviewStep} onClick={handleNext}>
+              {isLastStep ? (
+                <>
+                  <Send className="size-3.5 mr-1.5" />
+                  {submit_label || t('chat.form.submit')}
+                </>
+              ) : (
+                <>
+                  {t('chat.wizard.next')}
+                  <ChevronRight className="size-3.5 ml-1" />
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Field widget (same as FormBlock's FormFieldWidget) ───
+
+function WizardFieldWidget({
+  field,
+  value,
+  error,
+  disabled,
+  onChange,
+  onToggleMulti,
+}: {
+  field: AskUserQuestion;
+  value: FieldValue;
+  error?: string;
+  disabled: boolean;
+  onChange: (val: FieldValue) => void;
+  onToggleMulti: (val: string) => void;
+}) {
+  const type = field.type ?? 'text';
+  const isMulti = type === 'multi_select' || field.multiple;
+  const options = field.options?.filter(
+    (o): o is NonNullable<typeof field.options>[number] => !!o && typeof o.label === 'string'
+  ) ?? [];
+
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-xs font-medium flex items-center gap-1">
+        {field.question}
+        {field.required && <span className="text-destructive">*</span>}
+      </Label>
+      {field.message && (
+        <p className="text-[0.65rem] text-muted-foreground whitespace-pre-wrap">{field.message}</p>
+      )}
+
+      {/* Text */}
+      {type === 'text' && (
+        <Input
+          value={(value as string) ?? ''}
+          placeholder={field.placeholder ?? ''}
+          disabled={disabled}
+          onChange={e => onChange(e.target.value)}
+          className="h-8 text-xs"
+        />
+      )}
+
+      {/* Textarea */}
+      {type === 'textarea' && (
+        <Textarea
+          value={(value as string) ?? ''}
+          placeholder={field.placeholder ?? ''}
+          disabled={disabled}
+          rows={3}
+          onChange={e => onChange(e.target.value)}
+          className="text-xs resize-y"
+        />
+      )}
+
+      {/* Dropdown */}
+      {type === 'dropdown' && (
+        <select
+          value={(value as string) ?? ''}
+          disabled={disabled}
+          onChange={e => onChange(e.target.value)}
+          className="w-full h-8 rounded-md border border-input bg-background px-2.5 text-xs focus:outline-none focus:ring-1 focus:ring-primary/30"
+        >
+          <option value="">{field.placeholder || t('chat.form.selectPlaceholder')}</option>
+          {options.map(opt => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      )}
+
+      {/* Single select (radio) */}
+      {type === 'single_select' && (
+        <div className="space-y-1.5">
+          {options.map(opt => (
+            <label
+              key={opt.value}
+              className={`flex items-center gap-2 px-2.5 py-1.5 rounded-md border cursor-pointer text-xs transition-colors ${
+                disabled ? 'opacity-60 cursor-default' : 'hover:bg-accent/50'
+              } ${
+                value === opt.value ? 'border-primary bg-primary/10' : 'border-border'
+              }`}
+            >
+              <input
+                type="radio"
+                name={field.id}
+                value={opt.value}
+                checked={value === opt.value}
+                disabled={disabled}
+                onChange={e => onChange(e.target.value)}
+                className="size-3.5 accent-primary"
+              />
+              <span className="flex-1">{opt.label}</span>
+              {opt.recommended && (
+                <span className="text-[0.6rem] text-primary/70 font-medium px-1 py-0.5 rounded bg-primary/10">
+                  {t('chat.form.recommended')}
+                </span>
+              )}
+            </label>
+          ))}
+        </div>
+      )}
+
+      {/* Multi select (checkbox) */}
+      {isMulti && options.length > 0 && (
+        <div className="space-y-1.5">
+          <div className="space-y-1">
+            {options.map(opt => (
+              <label
+                key={opt.value}
+                className={`flex items-center gap-2 px-2.5 py-1.5 rounded-md border cursor-pointer text-xs transition-colors ${
+                  disabled ? 'opacity-60 cursor-default' : 'hover:bg-accent/50'
+                } ${
+                  Array.isArray(value) && value.includes(opt.value) ? 'border-primary bg-primary/10' : 'border-border'
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  value={opt.value}
+                  checked={Array.isArray(value) && value.includes(opt.value)}
+                  disabled={disabled}
+                  onChange={() => onToggleMulti(opt.value)}
+                  className="size-3.5 accent-primary rounded"
+                />
+                <span className="flex-1">{opt.label}</span>
+                {opt.recommended && (
+                  <span className="text-[0.6rem] text-primary/70 font-medium px-1 py-0.5 rounded bg-primary/10">
+                    {t('chat.form.recommended')}
+                  </span>
+                )}
+              </label>
+            ))}
+          </div>
+          {(field.min_select || field.max_select) && (
+            <p className="text-[0.65rem] text-muted-foreground">
+              {field.min_select && field.max_select
+                ? t('chat.form.selectRange', [String(field.min_select), String(field.max_select)])
+                : field.min_select
+                  ? t('chat.form.minSelect', [String(field.min_select)])
+                  : field.max_select
+                    ? t('chat.form.maxSelect', [String(field.max_select)])
+                    : null}
+            </p>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <p className="text-[0.65rem] text-destructive mt-1">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/lib/agent/system-prompt.ts
+++ b/lib/agent/system-prompt.ts
@@ -56,7 +56,7 @@ Virtual Filesystem (see Environment):
 - **fs_save_url** — fetch a URL and stream the response body straight into a VFS file.
 
 User & skills:
-- **ask_user** — pause and ask the user a question, with optional clickable choices.
+- **ask_user** — pause and ask the user a question, present a multi-field form, or request a decision. Always use the \`questions\` array. For a single question, pass one question object with id, question, and optional options/type. For collecting multiple related fields at once (e.g. configuration, preferences, data entry), pass multiple questions with an optional \`title\` — this presents a structured form so the user fills all fields at once and submits.
 - **run_skill** — execute a JavaScript file from an installed skill package in a sandbox.
 - The user may also enable **MCP tools** from external servers — these appear in your tool list alongside the built-ins; consult each one's own schema description for usage.
 
@@ -66,7 +66,7 @@ User & skills:
 
 - Pick tools by the **type of question**, not by order: \`inspect\` for structure/state, \`read_page\` for text content, \`screenshot\` for rendered pixels.
 - Before answering questions about page content, always call read_page first — EXCEPT when the active tab's context block contains \`contentType: application/pdf\`, in which case use the \`pdf\` tool directly (start with \`action: "info"\` for page count + outline, then \`action: "read"\` or \`action: "search"\`). If \`pdf read\` returns empty or whitespace-only text, the PDF is likely scanned (image-only, no text layer) — fall back to \`screenshot\` of the tab for vision-based extraction.
-- When you need the user to decide, confirm, or clarify anything, prioritize using the ask_user tool over writing questions in plain text. This gives the user a structured prompt with clickable options.
+- When you need the user to decide, confirm, or clarify anything, prioritize using the ask_user tool over writing questions in plain text. This gives the user a structured prompt with clickable options. When you need to collect several related pieces of information at once (configuration, preferences, survey-style questions, data entry), use the \`questions\` array with an optional \`title\` — the user sees a form with all fields and submits once, rather than going back and forth through multiple ask_user turns.
 - If the user's request needs info beyond the current page, proactively open new tabs to browse and synthesize — but only from a grounded starting URL (user / current page / prior tool result). With no grounded URL to open, \`ask_user\` instead of inventing one.
 
 ### Following Links & URLs

--- a/lib/tools/ask-user-registry.tsx
+++ b/lib/tools/ask-user-registry.tsx
@@ -2,7 +2,7 @@
 // Import this file once in the sidepanel to enable rendering ask_user blocks.
 
 import { uiToolRegistry, type InteractiveToolComponentProps } from './ui-registry';
-import type { AskUserRequest } from './ask-user';
+import type { AskUserRequest, AskUserResponse } from './ask-user';
 import { AskUserBlock } from '@/components/chat/Message';
 import { TOOL_ASK_USER } from '@/lib/tools/names';
 
@@ -16,11 +16,9 @@ function AskUserToolComponent({
 }: InteractiveToolComponentProps<AskUserRequest>) {
   return (
     <AskUserBlock
-      question={args.question}
-      options={args.options}
-      allowFreeText={args.allow_free_text ?? true}
+      request={args}
       answered={!isPending && !!toolResult}
-      onSelect={isPending ? onResolve : undefined}
+      onResolve={isPending && onResolve ? (response: AskUserResponse) => onResolve(response as any) : undefined}
     />
   );
 }

--- a/lib/tools/ask-user.ts
+++ b/lib/tools/ask-user.ts
@@ -93,6 +93,23 @@ const AskUserQuestion = Type.Object({
       description: 'Maximum number of selections. Only meaningful for multi_select.',
     }),
   ),
+
+  // ── Wizard pagination ──
+  step: Type.Optional(
+    Type.Number({
+      description:
+        'Assigns this question to a specific step/page in wizard mode. ' +
+        '1-based. Questions without step are grouped in step 1 by default. ' +
+        'Only meaningful when pagination.type is "wizard".',
+    }),
+  ),
+  step_title: Type.Optional(
+    Type.String({
+      description:
+        'Title shown for this step in the wizard progress indicator. ' +
+        'Questions in the same step should share the same step_title.',
+    }),
+  ),
 });
 
 // ─── Top-level parameters (new, multi-field schema) ───
@@ -118,6 +135,34 @@ const AskUserNewParams = Type.Object({
       description: 'Submit button text. Defaults to "Submit" per locale.',
     }),
   ),
+
+  // ── Wizard pagination ──
+  pagination: Type.Optional(
+    Type.Object({
+      type: Type.Literal('wizard', {
+        description: 'Pagination style. Currently only "wizard" is supported.',
+      }),
+      show_progress: Type.Optional(
+        Type.Boolean({
+          description:
+            'Whether to show a step progress indicator. Defaults to true.',
+        }),
+      ),
+      allow_skip: Type.Optional(
+        Type.Boolean({
+          description:
+            'Whether users can skip non-required steps. Defaults to false.',
+        }),
+      ),
+      allow_review: Type.Optional(
+        Type.Boolean({
+          description:
+            'Whether to show a final review step before submit. Defaults to true.',
+        }),
+      ),
+    }),
+  ),
+
   questions: Type.Array(AskUserQuestion, {
     minItems: 1,
     description:
@@ -250,9 +295,10 @@ const ASK_USER_META = {
     'Ask the user questions, present a form, or request a decision. ' +
     'Always use the `questions` array. ' +
     'For a single simple question, pass one question object with id, question, and optional options/type. ' +
-    'For collecting multiple related fields at once (e.g. configuration, preferences, ' +
-    'data entry), pass multiple questions with an optional `title` — this presents ' +
-    'a structured form so the user can fill all fields at once. ' +
+    'For collecting multiple related fields at once (e.g. configuration), ' +
+    'pass multiple questions with an optional `title` — this presents a form. ' +
+    'For multi-step workflows (e.g. setup wizards), add `pagination: { type: "wizard" }` ' +
+    'and assign each question a `step` number plus a `step_title`. ' +
     'Prioritize this tool over writing questions in plain text — ' +
     'it gives the user a structured prompt. Provide clear options when possible.',
   parameters: AskUserNewParams,

--- a/lib/tools/ask-user.ts
+++ b/lib/tools/ask-user.ts
@@ -3,9 +3,132 @@ import type { AgentTool, AgentToolResult } from '@earendil-works/pi-agent-core';
 import { createInteractiveBridge, INTERACTIVE_CANCELLED, type InteractiveBridge } from './interactive-bridge';
 import { TOOL_ASK_USER } from '@/lib/tools/names';
 
-// ─── Request type ───
+// ─── Types ───
 
-const AskUserParameters = Type.Object({
+/** A single selectable option with optional description and recommended flag. */
+export const AskUserOption = Type.Object({
+  label: Type.String({ description: 'Display text for this option.' }),
+  value: Type.String({ description: 'Machine-readable value returned when selected.' }),
+  description: Type.Optional(
+    Type.String({ description: 'Optional helper text shown alongside the option.' }),
+  ),
+  recommended: Type.Optional(
+    Type.Boolean({
+      description:
+        'Whether this option is the recommended default. ' +
+        'UI should show a "Recommended" badge.',
+    }),
+  ),
+});
+
+/** A single question/field within an ask_user request. */
+const AskUserQuestion = Type.Object({
+  // ── Identity ──
+  id: Type.String({
+    description:
+      'Machine-readable answer key. Not shown to the user. ' +
+      'Must be unique within this ask_user request.',
+  }),
+
+  // ── Field type ──
+  type: Type.Optional(
+    Type.Union([
+      Type.Literal('text'),
+      Type.Literal('textarea'),
+      Type.Literal('single_select'),
+      Type.Literal('multi_select'),
+      Type.Literal('dropdown'),
+    ], {
+      description: 'Field type. Defaults to "text" when omitted.',
+    }),
+  ),
+
+  // ── Display ──
+  question: Type.String({
+    description:
+      'The question shown to the user. Plain text only; Markdown is not rendered. ' +
+      'Use newline characters (\\n) for line breaks.',
+  }),
+  message: Type.Optional(
+    Type.String({
+      description: 'Optional supporting text shown below the question. Plain text only.',
+    }),
+  ),
+  placeholder: Type.Optional(
+    Type.String({ description: 'Placeholder text shown inside the input when empty.' }),
+  ),
+
+  // ── Options (for select types) ──
+  options: Type.Optional(
+    Type.Array(AskUserOption, {
+      description: 'Choices for single_select, multi_select, and dropdown fields.',
+    }),
+  ),
+
+  // ── Constraints ──
+  required: Type.Optional(
+    Type.Boolean({ description: 'Whether the field must be filled. Defaults to false.' }),
+  ),
+  allow_free_text: Type.Optional(
+    Type.Boolean({
+      description:
+        'Whether the user can type a free-form answer. ' +
+        'Defaults to true when no options are provided, false when options exist.',
+    }),
+  ),
+  multiple: Type.Optional(
+    Type.Boolean({
+      description:
+        '[Deprecated — use type: "multi_select" instead] ' +
+        'Whether the user can select multiple options. Only valid with options. Defaults to false.',
+    }),
+  ),
+  min_select: Type.Optional(
+    Type.Number({
+      description: 'Minimum number of selections. Only meaningful for multi_select.',
+    }),
+  ),
+  max_select: Type.Optional(
+    Type.Number({
+      description: 'Maximum number of selections. Only meaningful for multi_select.',
+    }),
+  ),
+});
+
+// ─── Top-level parameters (new, multi-field schema) ───
+
+const AskUserNewParams = Type.Object({
+  title: Type.Optional(
+    Type.String({
+      description:
+        'Form-level title shown at the top. ' +
+        'Useful when asking multiple related questions (e.g. "User Registration"). ' +
+        'When omitted with a single question, no title is shown and UI stays compact.',
+    }),
+  ),
+  description: Type.Optional(
+    Type.String({
+      description:
+        'Form-level explanatory text shown below the title. ' +
+        'Useful for providing context before multiple questions.',
+    }),
+  ),
+  submit_label: Type.Optional(
+    Type.String({
+      description: 'Submit button text. Defaults to "Submit" per locale.',
+    }),
+  ),
+  questions: Type.Array(AskUserQuestion, {
+    minItems: 1,
+    description:
+      'One or more questions to ask. ' +
+      'A single question with no title uses compact mode; multiple questions or a title trigger form mode.',
+  }),
+});
+
+// ─── Legacy parameters (single question, backward compatible) ───
+
+const AskUserLegacyParams = Type.Object({
   question: Type.String({
     description:
       'The question to ask the user. Plain text only — Markdown is not rendered. ' +
@@ -24,13 +147,95 @@ const AskUserParameters = Type.Object({
   ),
   allow_free_text: Type.Optional(
     Type.Boolean({
-      description:
-        'Whether the user can type a free-form answer. Defaults to true.',
+      description: 'Whether the user can type a free-form answer. Defaults to true.',
     }),
   ),
 });
 
-export type AskUserRequest = Static<typeof AskUserParameters>;
+// ─── Request types ───
+
+export type AskUserOption = Static<typeof AskUserOption>;
+export type AskUserQuestion = Static<typeof AskUserQuestion>;
+
+/** Legacy single-question request (backward compatible). */
+export type AskUserLegacyRequest = Static<typeof AskUserLegacyParams>;
+
+/** New multi-field request. */
+export type AskUserNewRequest = Static<typeof AskUserNewParams>;
+
+/** The normalized internal request type that the UI always receives. */
+export interface AskUserRequest extends AskUserNewRequest {}
+
+// ─── Response types ───
+
+/** A single field's answer. */
+export interface AskUserAnswer {
+  /** Answer value. Type depends on field type:
+   *  text/textarea/single_select/dropdown → string.
+   *  multi_select → string[].
+   *  Unfilled optional fields → null. */
+  value: string | string[] | null;
+  /** Whether the user explicitly skipped this question. Defaults to false. */
+  skipped?: boolean;
+}
+
+export type AskUserResponse =
+  | { answers: Record<string, AskUserAnswer> }
+  | { cancelled: true };
+
+// ─── Normalization: legacy → new ───
+
+export function normalizeRequest(raw: Record<string, unknown>): AskUserRequest {
+  // New format: has `questions` array
+  if (Array.isArray(raw.questions) && raw.questions.length > 0) {
+    return raw as unknown as AskUserRequest;
+  }
+
+  // Legacy format: single question
+  const legacy = raw as unknown as AskUserLegacyRequest;
+  const question: AskUserQuestion = {
+    id: 'q0',
+    question: legacy.question,
+    type: (legacy.options && legacy.options.length > 0) ? 'single_select' : 'text',
+    allow_free_text: legacy.allow_free_text,
+  };
+
+  if (legacy.options) {
+    question.options = legacy.options.map(opt => {
+      const labelStr = String(opt.label ?? '');
+      return {
+        label: labelStr,
+        value: labelStr,
+        description: 'description' in opt ? (opt as any).description : undefined,
+      };
+    });
+  }
+
+  return { questions: [question] };
+}
+
+// ─── Response normalization: new → legacy string ───
+
+function normalizeResponse(response: AskUserResponse): string {
+  if ('cancelled' in response) {
+    return 'User skipped this question.';
+  }
+  const answers = response.answers;
+  if (!answers) return '';
+
+  // Build a readable summary for the LLM
+  const parts: string[] = [];
+  for (const [id, answer] of Object.entries(answers)) {
+    if (answer.skipped) {
+      parts.push(`${id}: skipped`);
+    } else if (Array.isArray(answer.value)) {
+      parts.push(`${id}: [${answer.value.join(', ')}]`);
+    } else {
+      parts.push(`${id}: ${answer.value ?? ''}`);
+    }
+  }
+  return parts.length > 0 ? parts.join('\n') : '';
+}
 
 // ─── Tool details ───
 
@@ -38,44 +243,53 @@ interface AskUserDetails {
   cancelled: boolean;
 }
 
-// ─── Shared tool metadata (reused by createSessionAskUserTool) ───
-
-export const ASK_USER_META = {
+const ASK_USER_META = {
   name: TOOL_ASK_USER,
   label: 'Ask User',
   description:
-    'Ask the user a question, present choices, or request a decision. ' +
+    'Ask the user questions, present a form, or request a decision. ' +
+    'Always use the `questions` array. ' +
+    'For a single simple question, pass one question object with id, question, and optional options/type. ' +
+    'For collecting multiple related fields at once (e.g. configuration, preferences, ' +
+    'data entry), pass multiple questions with an optional `title` — this presents ' +
+    'a structured form so the user can fill all fields at once. ' +
     'Prioritize this tool over writing questions in plain text — ' +
-    'it gives the user a structured prompt with clickable options. ' +
-    'Provide clear options when possible. The user may also type a free-form answer.',
-  parameters: AskUserParameters,
+    'it gives the user a structured prompt. Provide clear options when possible.',
+  parameters: AskUserNewParams,
 } as const;
 
-// ─── Factory: creates a session-specific ask_user tool + bridge ───
+// ─── Factory ───
 
 export function createSessionAskUserTool(): {
-  tool: AgentTool<typeof AskUserParameters, AskUserDetails>;
-  bridge: InteractiveBridge<AskUserRequest, string>;
+  tool: AgentTool<any, AskUserDetails>;
+  bridge: InteractiveBridge<AskUserRequest, AskUserResponse>;
 } {
-  const bridge = createInteractiveBridge<AskUserRequest, string>();
+  const bridge = createInteractiveBridge<AskUserRequest, AskUserResponse>();
 
-  const tool: AgentTool<typeof AskUserParameters, AskUserDetails> = {
+  const tool: AgentTool<any, AskUserDetails> = {
     ...ASK_USER_META,
     async execute(toolCallId, params, signal): Promise<AgentToolResult<AskUserDetails>> {
-      const result = await bridge.request(toolCallId, params, signal);
+      // Normalize legacy params to the new internal format
+      const normalized = normalizeRequest(params as Record<string, unknown>);
+      const result = await bridge.request(toolCallId, normalized, signal);
 
       if (result === INTERACTIVE_CANCELLED) {
         return {
-          // English by design: this text is LLM-facing tool result context, not
-          // user-visible UI. The structured `details.cancelled` flag is the
-          // canonical signal; the text is purely for the model's reasoning.
           content: [{ type: 'text', text: 'User skipped this question.' }],
           details: { cancelled: true },
         };
       }
 
+      if ('cancelled' in result) {
+        return {
+          content: [{ type: 'text', text: 'User skipped this question.' }],
+          details: { cancelled: true },
+        };
+      }
+
+      const text = normalizeResponse(result);
       return {
-        content: [{ type: 'text', text: result }],
+        content: [{ type: 'text', text: text }],
         details: { cancelled: false },
       };
     },
@@ -83,3 +297,5 @@ export function createSessionAskUserTool(): {
 
   return { tool, bridge };
 }
+
+export { ASK_USER_META };

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -410,6 +410,18 @@ chat:
     autoStoppedTime: "Recording auto-stopped: time limit reached"
   askUser:
     placeholder: "Type a reply…"
+  form:
+    title: "Form"
+    submit: "Submit"
+    required: "This field is required"
+    selectPlaceholder: "Select…"
+    recommended: "Recommended"
+    # $1 = min, $2 = max
+    selectRange: "Select $1-$2 options"
+    # $1 = min
+    minSelect: "Select at least $1 option(s)"
+    # $1 = max
+    maxSelect: "Select at most $1 option(s)"
   permission:
     # Permission prompt shown before a skill script runs. $1 = skill name, $2 = script path
     title: "Skill $1 wants to run $2"
@@ -569,6 +581,7 @@ tools:
   executeJs: "Running script"
   screenshot: "Taking page screenshot"
   askUser: "Waiting for user reply"
+  presentForm: "Collecting user input"
   pdf:
     info: "Reading PDF metadata"
     # $1 = page range (e.g. "1-10") or the literal "all pages"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -422,6 +422,16 @@ chat:
     minSelect: "Select at least $1 option(s)"
     # $1 = max
     maxSelect: "Select at most $1 option(s)"
+  wizard:
+    step: "Step"
+    # $1 = current, $2 = total
+    stepOf: "$1 / $2"
+    prev: "Previous"
+    next: "Next"
+    skip: "Skip"
+    review: "Review"
+    reviewDesc: "Review your answers before submitting."
+    notFilled: "Not filled"
   permission:
     # Permission prompt shown before a skill script runs. $1 = skill name, $2 = script path
     title: "Skill $1 wants to run $2"

--- a/locales/zh_CN.yml
+++ b/locales/zh_CN.yml
@@ -418,6 +418,16 @@ chat:
     minSelect: "请至少选择 $1 个选项"
     # $1 = max
     maxSelect: "最多选择 $1 个选项"
+  wizard:
+    step: "步骤"
+    # $1 = current, $2 = total
+    stepOf: "$1 / $2"
+    prev: "上一步"
+    next: "下一步"
+    skip: "跳过"
+    review: "确认"
+    reviewDesc: "提交前请检查您的答案。"
+    notFilled: "未填写"
   permission:
     # 技能脚本运行前的授权提示。$1 = 技能名，$2 = 脚本路径
     title: "技能 $1 想要运行 $2"

--- a/locales/zh_CN.yml
+++ b/locales/zh_CN.yml
@@ -406,6 +406,18 @@ chat:
     autoStoppedTime: "录制已自动停止：达到时长上限"
   askUser:
     placeholder: "输入回复…"
+  form:
+    title: "表单"
+    submit: "提交"
+    required: "此项为必填"
+    selectPlaceholder: "请选择…"
+    recommended: "推荐"
+    # $1 = min, $2 = max
+    selectRange: "请选择 $1-$2 个选项"
+    # $1 = min
+    minSelect: "请至少选择 $1 个选项"
+    # $1 = max
+    maxSelect: "最多选择 $1 个选项"
   permission:
     # 技能脚本运行前的授权提示。$1 = 技能名，$2 = 脚本路径
     title: "技能 $1 想要运行 $2"
@@ -556,6 +568,7 @@ tools:
   executeJs: "正在执行脚本"
   screenshot: "正在截取页面截图"
   askUser: "等待用户回答"
+  presentForm: "收集用户输入"
   pdf:
     info: "正在读取 PDF 元信息"
     # $1 = 页码范围（如 "1-10"）或字面量 "all pages"

--- a/locales/zh_TW.yml
+++ b/locales/zh_TW.yml
@@ -406,6 +406,18 @@ chat:
     autoStoppedTime: "錄製已自動停止：達到時長上限"
   askUser:
     placeholder: "輸入回覆…"
+  form:
+    title: "表單"
+    submit: "提交"
+    required: "此項為必填"
+    selectPlaceholder: "請選擇…"
+    recommended: "推薦"
+    # $1 = min, $2 = max
+    selectRange: "請選擇 $1-$2 個選項"
+    # $1 = min
+    minSelect: "請至少選擇 $1 個選項"
+    # $1 = max
+    maxSelect: "最多選擇 $1 個選項"
   permission:
     # 技能腳本執行前的授權提示。$1 = 技能名，$2 = 腳本路徑
     title: "技能 $1 想要執行 $2"
@@ -556,6 +568,7 @@ tools:
   executeJs: "正在執行腳本"
   screenshot: "正在擷取頁面螢幕截圖"
   askUser: "等待使用者回覆"
+  presentForm: "收集使用者輸入"
   pdf:
     info: "正在讀取 PDF 資訊"
     # $1 = 頁碼範圍（如 "1-10"）或字面量 "all pages"

--- a/locales/zh_TW.yml
+++ b/locales/zh_TW.yml
@@ -418,6 +418,16 @@ chat:
     minSelect: "請至少選擇 $1 個選項"
     # $1 = max
     maxSelect: "最多選擇 $1 個選項"
+  wizard:
+    step: "步驟"
+    # $1 = current, $2 = total
+    stepOf: "$1 / $2"
+    prev: "上一步"
+    next: "下一步"
+    skip: "跳過"
+    review: "確認"
+    reviewDesc: "提交前請檢查您的答案。"
+    notFilled: "未填寫"
   permission:
     # 技能腳本執行前的授權提示。$1 = 技能名，$2 = 腳本路徑
     title: "技能 $1 想要執行 $2"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: set this to true or false
+  simple-git-hooks: set this to true or false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,0 @@
-allowBuilds:
-  esbuild: set this to true or false
-  simple-git-hooks: set this to true or false


### PR DESCRIPTION
<!-- 
 Thanks for contributing to Cebian! 
 
 ⚠️ 提交前必读 / READ BEFORE OPENING: 
 本项目要求所有 PR 必须关联一个带有 `ready-to-implement` 标签的 issue，不符合此要求的 PR 将被机器人自动关闭。请先在对应 issue 里讨论你的实现方案，待该 issue 打上 `ready-to-implement` 标签后，再提交 PR，并在描述中写明 `Closes #<issue 编号>`。 
 
 Every PR must reference an issue carrying the `ready-to-implement` label; PRs that don't 
 will be auto-closed by a bot. Please discuss your approach in the issue first, then open 
 the PR with `Closes #<issue number>` in the description once the label is applied. 
 
 Before submitting, please confirm: 
 - [x] `pnpm run check` passes locally 
 - [x] Commit messages are concise and scoped 
 - [x] I have read and agree to the [Cebian CLA](../CLA.md) 
 --> 

## Summary

增强 `ask_user` 工具交互能力，在原有单问题模式（紧凑模式）基础上新增两种模式：

- **模式 B — 多字段表单（Form）**：AI 可同时提出多个问题，渲染为结构化表单（支持 text、textarea、单选、多选、下拉 5 种字段类型），并附带前端校验。
- **模式 C — 分步向导（Wizard）**：将一组问题拆分为多个步骤，逐步引导用户填写，支持进度指示、上一步/下一步/跳过导航，最后一步为回顾确认页。

实现上保持完全向后兼容：原有单问题调用格式通过 `normalizeRequest()` 透明转换为新模式参数，旧发起方无需任何修改即可继续使用。

### 变更文件（9 files, +1233 / -47）

| 文件 | 说明 |
|---|---|
| `lib/tools/ask-user.ts` | 参数 schema 重写，新增 `AskUserNewParams` / `AskUserLegacyParams`，`normalizeRequest()` 兼容旧格式 |
| `lib/tools/ask-user-registry.tsx` | 交互桥适配新模式 |
| `lib/agent/system-prompt.ts` | ask_user 工具描述更新，提及三种模式 |
| `components/chat/Message.tsx` | `AskUserBlock` 入口重构，按模式分发到对应子组件 |
| `components/chat/FormBlock.tsx` | **新增** 多字段表单组件（311 行） |
| `components/chat/WizardBlock.tsx` | **新增** 分步向导组件（493 行） |
| `locales/en.yml` | 新增 `chat.form.*` 和 `chat.wizard.*` 英文 key |
| `locales/zh_CN.yml` | 新增 `chat.form.*` 和 `chat.wizard.*` 简体中文 key |
| `locales/zh_TW.yml` | 新增 `chat.form.*` 和 `chat.wizard.*` 繁体中文 key |

## Related Issues

Closes #28

## Testing

- `pnpm run check`（tsc + vitest 199 用例）全部通过
- 在侧边栏中分别测试了三种模式：
  - 紧凑模式（模式 A）：现有单问题交互不受影响
  - 表单模式（模式 B）：多字段渲染、字段校验、提交和取消
  - 向导模式（模式 C）：步骤导航、字段校验、回顾确认、最终提交

<img width="715" height="745" alt="1" src="https://github.com/user-attachments/assets/8d5de1e5-6468-4923-8c10-9a969b0d766c" />
<img width="715" height="755" alt="2" src="https://github.com/user-attachments/assets/daaef376-b4c1-4579-b18b-0247571747ed" />
<img width="715" height="635" alt="3" src="https://github.com/user-attachments/assets/02e6eda4-097d-4d22-a3ec-ea9f6ddf4493" />


## Checklist

- [x] `pnpm run check` passes locally
- [x] I have read and agree to the [Cebian CLA](../CLA.md)