### PR TITLE
feat(page-actions): 翻译时显示读音（拼音/音标）

### DIFF
--- a/components/settings/sections/PageInteractionSection.tsx
+++ b/components/settings/sections/PageInteractionSection.tsx
@@ -171,6 +171,23 @@ export function PageInteractionSection() {
           />
         </div>
       </div>
+
+      <div className="flex items-center justify-between gap-4">
+        <div className="min-w-0 space-y-1">
+          <Label htmlFor="page-show-pronunciation" className="text-sm">
+            {t('settings.pageInteraction.pronunciation.label')}
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            {t('settings.pageInteraction.pronunciation.hint')}
+          </p>
+        </div>
+        <Switch
+          id="page-show-pronunciation"
+          checked={settings.showPronunciation}
+          onCheckedChange={(v) => patch({ showPronunciation: v })}
+          className="shrink-0"
+        />
+      </div>
     </div>
   );
 }

--- a/entrypoints/background/page-action-runner.ts
+++ b/entrypoints/background/page-action-runner.ts
@@ -39,7 +39,10 @@ function languageName(code: string): string {
 function resolveParams(actionId: PageActionId, settings: PageInteractionSettings): PageActionParams {
   const uiLang = chrome.i18n.getUILanguage();
   if (actionId === 'translate') {
-    return { target: languageName(settings.translateTarget || uiLang) };
+    return {
+      target: languageName(settings.translateTarget || uiLang),
+      pronunciation: settings.showPronunciation,
+    };
   }
   return { lang: languageName(uiLang) };
 }

--- a/lib/page-actions/actions.ts
+++ b/lib/page-actions/actions.ts
@@ -23,6 +23,12 @@ function str(params: PageActionParams, key: string, fallback: string): string {
   return typeof v === 'string' && v ? v : fallback;
 }
 
+/** 从参数中取布尔值；缺省 / 类型不对时回退 fallback。 */
+function bool(params: PageActionParams, key: string, fallback: boolean): boolean {
+  const v = params[key];
+  return typeof v === 'boolean' ? v : fallback;
+}
+
 /** 若带有界上下文（页面标题 + 选区周边），拼成一段「仅供消歧的参考」附在 system 末尾。
  *  只进 system、不进 user turn，故「在侧边栏继续」固化的历史里 user 消息仍是干净意图。 */
 function contextBlock(params: PageActionParams): string {
@@ -39,10 +45,35 @@ const TRANSLATE: PageActionDef = {
   id: 'translate',
   renderSystemPrompt: (p) => {
     const target = str(p, 'target', 'English');
+    const showPronunciation = bool(p, 'pronunciation', false);
+
+    if (!showPronunciation) {
+      return (
+        `You are a professional translator. Translate the user's text into ${target}. ` +
+        'Preserve the original meaning and tone. ' +
+        'Output only the translated text as plain text — no markdown, explanations, notes, or surrounding quotes.' +
+        contextBlock(p)
+      );
+    }
+
+    // 开启读音时，要求模型按固定 4 行格式输出：原文 → 原文读音 → 译文 → 译文读音。
+    // 长文本（超过 2 句）跳过读音，只输出译文，避免大段注音无意义。
     return (
       `You are a professional translator. Translate the user's text into ${target}. ` +
-      'Preserve the original meaning and tone. ' +
-      'Output only the translated text as plain text — no markdown, explanations, notes, or surrounding quotes.' +
+      'Preserve the original meaning and tone.\n\n' +
+      'Output format — follow strictly, plain text only, no markdown, no labels, no extra content:\n' +
+      'Line 1: the original text (copy exactly)\n' +
+      'Line 2: pronunciation of the original text\n' +
+      'Line 3: the translated text\n' +
+      'Line 4: pronunciation of the translated text\n\n' +
+      'Pronunciation rules:\n' +
+      '- Chinese text → Pinyin with tone marks (e.g., nǐ hǎo)\n' +
+      '- English text → IPA phonetic notation in slashes (e.g., /həˈloʊ/)\n' +
+      '- Japanese text → Romaji (e.g., konnichiwa)\n' +
+      '- Korean text → Revised Romanization (e.g., annyeonghaseyo)\n' +
+      '- Other languages → use the most common phonetic notation for that language\n\n' +
+      'If the text is a long paragraph (more than 2 sentences), skip pronunciation entirely ' +
+      'and output only the translated text as plain prose.' +
       contextBlock(p)
     );
   },

--- a/lib/persistence/storage.ts
+++ b/lib/persistence/storage.ts
@@ -295,6 +295,8 @@ export interface PageInteractionSettings {
   toolbarModel?: ModelIdentity;
   /** 翻译目标语言 BCP-47 代码；空串 = 跟随界面语言 */
   translateTarget: string;
+  /** 翻译时是否显示原文和译文的读音（拼音/音标）。默认 true */
+  showPronunciation: boolean;
 }
 
 /** 页面交互设置默认值（新装机 fallback + 旧装机字段回填共用单一真理源）。 */
@@ -302,6 +304,7 @@ const DEFAULT_PAGE_INTERACTION: PageInteractionSettings = {
   showFloatingBall: true,
   showSelectionToolbar: true,
   translateTarget: '',
+  showPronunciation: true,
 };
 
 /** 取规范的页面交互设置：补齐旧装机 / 部分写入缺失的字段。读设置的唯一入口。 */

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -160,6 +160,9 @@ settings:
       label: "Translation target language"
       hint: "The language the toolbar translates into."
       auto: "Follow interface language"
+    pronunciation:
+      label: "Show pronunciation"
+      hint: "Display phonetic reading (Pinyin for Chinese, IPA for English, etc.) alongside translation results."
   instructions:
     title: "Instructions"
     label: "Custom instructions"

--- a/locales/zh_CN.yml
+++ b/locales/zh_CN.yml
@@ -156,6 +156,9 @@ settings:
       label: "翻译目标语言"
       hint: "工具条翻译成的目标语言。"
       auto: "跟随界面语言"
+    pronunciation:
+      label: "显示读音"
+      hint: "翻译结果中显示原文和译文的读音（中文显示拼音，英文显示音标等）。"
   instructions:
     title: "指引"
     label: "自定义指引"

--- a/locales/zh_TW.yml
+++ b/locales/zh_TW.yml
@@ -156,6 +156,9 @@ settings:
       label: "翻譯目標語言"
       hint: "工具列翻譯成的目標語言。"
       auto: "跟隨介面語言"
+    pronunciation:
+      label: "顯示讀音"
+      hint: "翻譯結果中顯示原文和譯文的讀音（中文顯示拼音，英文顯示音標等）。"
   instructions:
     title: "指引"
     label: "自訂指引"


### PR DESCRIPTION
## 功能说明

选中文本点击翻译后，同时显示原文和译文的读音：
- 中文 → 拼音（如 nǐ hǎo）
- 英文 → IPA 音标（如 /həˈloʊ/）
- 日语 → 罗马字
- 韩语 → 罗马化拼音
- 长段落自动跳过读音，只输出译文

## 改动内容

| 文件 | 说明 |
|------|------|
| `lib/page-actions/actions.ts` | 翻译提示词增加读音输出指令 |
| `lib/persistence/storage.ts` | 新增 `showPronunciation` 设置项 |
| `entrypoints/background/page-action-runner.ts` | 传递读音设置到提示词参数 |
| `components/settings/sections/PageInteractionSection.tsx` | 设置面板新增「显示读音」开关 |
| `locales/en.yml` / `zh_CN.yml` / `zh_TW.yml` | 国际化文本 |

## 设置

设置 → 页面交互 → 显示读音（默认开启）

## 翻译效果示例

开启读音后，选中「你好」翻译为英文：
```
你好
nǐ hǎo
Hello
/həˈloʊ/
```

选中 Hello 翻译为中文：
```
Hello
/həˈloʊ/
你好
nǐ hǎo
```