### PR TITLE
feat(providers): add OrcaRouter as a named provider

### DIFF
--- a/components/chat/ModelSelector.tsx
+++ b/components/chat/ModelSelector.tsx
@@ -6,6 +6,7 @@ import { Check, ChevronDown, Settings } from 'lucide-react';
 
 import type { ModelIdentity, ProviderCredentials, CustomProviderConfig } from '@/lib/persistence/storage';
 import { isCustomProvider, findCustomProvider } from '@/lib/providers/custom-models';
+import { findOrcaRouterModel } from '@/lib/providers/orcarouter';
 import { listUsableModelGroups } from '@/lib/providers/usable-models';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -63,6 +64,10 @@ export function ModelSelector({
     }
 
     // Built-in provider
+    if (activeModel.provider === 'orcarouter') {
+      const orcaRouterModel = findOrcaRouterModel(activeModel.modelId);
+      if (orcaRouterModel) return orcaRouterModel.name;
+    }
     try {
       const models = getBuiltinModels(activeModel.provider as BuiltinProvider) as Model<Api>[];
       return models.find(m => m.id === activeModel.modelId)?.name ?? activeModel.modelId;

--- a/components/settings/provider/ProviderApiKeyItem.tsx
+++ b/components/settings/provider/ProviderApiKeyItem.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { Badge } from "@/components/ui/badge";
 import { isCustomProvider } from "@/lib/providers/custom-models";
+import { ORCAROUTER_MODELS, ORCAROUTER_PROVIDER } from "@/lib/providers/orcarouter";
 import { t } from "@/lib/i18n";
 import type { ApiKeyCredential } from "@/lib/persistence/storage";
 
@@ -42,7 +43,8 @@ export function ProviderApiKeyItem({
 
   const cheapestModel = useMemo(() => {
     try {
-      const models = modelsProp ?? (isCustomProvider(provider) ? [] : (getBuiltinModels(provider as BuiltinProvider) as Model<Api>[]));
+      const models = modelsProp
+        ?? (provider === ORCAROUTER_PROVIDER ? ORCAROUTER_MODELS : (isCustomProvider(provider) ? [] : (getBuiltinModels(provider as BuiltinProvider) as Model<Api>[])));
       if (models.length === 0) return undefined;
 
       return models.reduce((min, m) =>

--- a/components/settings/provider/ProviderSummary.tsx
+++ b/components/settings/provider/ProviderSummary.tsx
@@ -2,6 +2,7 @@ import { getBuiltinModels, type BuiltinProvider } from '@earendil-works/pi-ai/pr
 import type { Api, Model } from '@earendil-works/pi-ai';
 import type { ProviderCredential, CustomProviderConfig } from '@/lib/persistence/storage';
 import { isCustomProvider, findCustomProvider, getCustomModels } from '@/lib/providers/custom-models';
+import { ORCAROUTER_MODELS, ORCAROUTER_PROVIDER } from '@/lib/providers/orcarouter';
 import { t } from '@/lib/i18n';
 
 interface ProviderSummaryProps {
@@ -20,6 +21,10 @@ export function ProviderSummary({ provider, credential, customProviders }: Provi
       models = getCustomModels(config);
       displayName = config.name;
     }
+  } else if (provider === ORCAROUTER_PROVIDER) {
+    // OrcaRouter's catalog lives in Cebian, not in pi-ai's generated catalog.
+    models = ORCAROUTER_MODELS;
+    displayName = 'OrcaRouter';
   } else {
     try {
       models = getBuiltinModels(provider as BuiltinProvider) as Model<Api>[];

--- a/lib/providers/orcarouter.test.ts
+++ b/lib/providers/orcarouter.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ORCAROUTER_MODELS,
+  ORCAROUTER_PROVIDER,
+  ORCAROUTER_BASE_URL,
+  findOrcaRouterModel,
+} from '@/lib/providers/orcarouter';
+
+describe('orcarouter catalog', () => {
+  it('models point at the OrcaRouter OpenAI-compatible endpoint', () => {
+    for (const m of ORCAROUTER_MODELS) {
+      expect(m.provider).toBe(ORCAROUTER_PROVIDER);
+      expect(m.baseUrl).toBe(ORCAROUTER_BASE_URL);
+      expect(m.api).toBe('openai-completions');
+    }
+  });
+
+  it('models carry the Cebian attribution headers', () => {
+    for (const m of ORCAROUTER_MODELS) {
+      expect(m.headers?.['HTTP-Referer']).toBe('https://cebian.catcat.work');
+      expect(m.headers?.['X-Title']).toBe('Cebian');
+    }
+  });
+
+  it('includes the documented auto-routing entry', () => {
+    expect(findOrcaRouterModel('orcarouter/auto')).toBeDefined();
+  });
+
+  it('unknown model id → undefined', () => {
+    expect(findOrcaRouterModel('nope/nope')).toBeUndefined();
+  });
+});

--- a/lib/providers/orcarouter.ts
+++ b/lib/providers/orcarouter.ts
@@ -1,0 +1,64 @@
+// ─── OrcaRouter provider catalog ───
+
+import type { Api, Model } from '@earendil-works/pi-ai';
+
+export const ORCAROUTER_PROVIDER = 'orcarouter';
+export const ORCAROUTER_BASE_URL = 'https://api.orcarouter.ai/v1';
+
+// Cebian attribution headers, mirroring the OpenRouter integration. OrcaRouter
+// accepts HTTP-Referer / X-Title on its OpenAI-compatible endpoint so requests
+// are attributed back to Cebian in its request log.
+const ORCAROUTER_HEADERS = {
+  'HTTP-Referer': 'https://cebian.catcat.work',
+  'X-Title': 'Cebian',
+} as const;
+
+function orcaRouterModel(
+  id: string,
+  name: string,
+  reasoning: boolean,
+): Model<Api> {
+  return {
+    id,
+    name,
+    api: 'openai-completions',
+    provider: ORCAROUTER_PROVIDER,
+    baseUrl: ORCAROUTER_BASE_URL,
+    reasoning,
+    // Routing models forward to whatever upstream the gateway picks, so the
+    // safest capability set is text-only — an image request could otherwise be
+    // routed to a text-only upstream and fail.
+    input: ['text'],
+    // The gateway's pricing depends on the upstream it routes to, which Cebian
+    // cannot know ahead of time; zero cost keeps these out of "cheapest model"
+    // heuristics without inventing numbers.
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128000,
+    // No fixed output cap — let the per-request maxTokens setting decide.
+    maxTokens: 0,
+    headers: { ...ORCAROUTER_HEADERS },
+    // OrcaRouter speaks the same reasoning format as OpenRouter (top-level
+    // `reasoning: { effort }`), so reasoning-capable models use that compat.
+    ...(reasoning ? { compat: { thinkingFormat: 'openrouter' as const } } : {}),
+  };
+}
+
+/**
+ * The native OrcaRouter routing models. These are the unique value of the
+ * gateway: they auto-route across upstream vendors instead of pinning one, so
+ * they belong here as a first-class provider. Vendor-prefixed models (e.g.
+ * `deepseek/deepseek-chat`) are intentionally omitted — Cebian already ships
+ * dedicated providers for those vendors, and OrcaRouter exposes hundreds of
+ * them with no per-model metadata to curate against.
+ */
+export const ORCAROUTER_MODELS: Model<Api>[] = [
+  orcaRouterModel('orcarouter/auto', 'OrcaRouter Auto', true),
+  orcaRouterModel('orcarouter/free', 'OrcaRouter Free', false),
+  orcaRouterModel('orcarouter/fusion', 'OrcaRouter Fusion', true),
+  orcaRouterModel('orcarouter/fusion-flash', 'OrcaRouter Fusion Flash', true),
+  orcaRouterModel('orcarouter/fusion-mini', 'OrcaRouter Fusion Mini', true),
+];
+
+export function findOrcaRouterModel(modelId: string): Model<Api> | undefined {
+  return ORCAROUTER_MODELS.find((m) => m.id === modelId);
+}

--- a/lib/providers/registry.ts
+++ b/lib/providers/registry.ts
@@ -30,6 +30,7 @@ export const APIKEY_PROVIDERS = [
   { provider: 'nvidia', label: 'NVIDIA NIM' },
   { provider: 'openai', label: 'OpenAI', pinned: true },
   { provider: 'openrouter', label: 'OpenRouter', pinned: true },
+  { provider: 'orcarouter', label: 'OrcaRouter' },
   { provider: 'together', label: 'Together AI' },
   { provider: 'vercel-ai-gateway', label: 'Vercel AI Gateway' },
   { provider: 'xai', label: 'xAI' },

--- a/lib/providers/resolve-model.test.ts
+++ b/lib/providers/resolve-model.test.ts
@@ -86,6 +86,18 @@ describe('resolveModel — built-in provider', () => {
     expect(model).not.toBeNull();
     expect(model!.headers?.['HTTP-Referer']).toBeUndefined();
   });
+
+  it('orcarouter 从本地目录解析，且带 Cebian 归因头', () => {
+    const model = resolveModel({ provider: 'orcarouter', modelId: 'orcarouter/auto' }, NO_CREDS, NO_CUSTOM);
+    expect(model).not.toBeNull();
+    expect(model!.baseUrl).toBe('https://api.orcarouter.ai/v1');
+    expect(model!.headers?.['HTTP-Referer']).toBe('https://cebian.catcat.work');
+    expect(model!.headers?.['X-Title']).toBe('Cebian');
+  });
+
+  it('orcarouter 下未知 modelId → null', () => {
+    expect(resolveModel({ provider: 'orcarouter', modelId: 'nope' }, NO_CREDS, NO_CUSTOM)).toBeNull();
+  });
 });
 
 describe('resolveModel — github-copilot baseUrl', () => {

--- a/lib/providers/resolve-model.ts
+++ b/lib/providers/resolve-model.ts
@@ -7,6 +7,7 @@ import type {
 } from '@/lib/persistence/storage';
 import { isCustomProvider, findCustomModel } from '@/lib/providers/custom-models';
 import { getCopilotBaseUrl } from '@/lib/providers/oauth';
+import { findOrcaRouterModel } from '@/lib/providers/orcarouter';
 
 /**
  * 把一个模型身份（provider key + modelId）解析成可用的 pi-ai 运行时 `Model`。
@@ -17,7 +18,7 @@ import { getCopilotBaseUrl } from '@/lib/providers/oauth';
  *
  * 解析不出（未知内置 provider / 自定义模型查无 / modelId 不存在）时返回 null，由调用
  * 方决定如何「诚实报错」。custom provider 查表、copilot OAuth baseUrl、openrouter 归因
- * 头三条特例都在此处理，保证无论身份来自全局还是会话都一致。
+ * 头、orcarouter 本地目录四条特例都在此处理，保证无论身份来自全局还是会话都一致。
  */
 export function resolveModel(
   identity: ModelIdentity,
@@ -28,6 +29,10 @@ export function resolveModel(
 
   if (isCustomProvider(identity.provider)) {
     model = findCustomModel(customProviders, identity.provider, identity.modelId) ?? undefined;
+  } else if (identity.provider === 'orcarouter') {
+    // OrcaRouter's native catalog lives in Cebian (see orcarouter.ts), not in
+    // pi-ai's generated catalog, so resolve it separately.
+    model = findOrcaRouterModel(identity.modelId);
   } else {
     try {
       const models = getBuiltinModels(identity.provider as BuiltinProvider) as Model<Api>[];

--- a/lib/providers/usable-models.test.ts
+++ b/lib/providers/usable-models.test.ts
@@ -68,4 +68,22 @@ describe('listUsableModelGroups / hasUsableModel', () => {
     };
     expect(hasUsableModel(verified, NO_CUSTOM)).toBe(true);
   });
+
+  it('orcarouter：填了 key 就列出本地目录模型', () => {
+    const creds: ProviderCredentials = {
+      orcarouter: { authType: 'apiKey', apiKey: 'sk-orca-x', verified: true },
+    };
+    const groups = listUsableModelGroups(creds, NO_CUSTOM);
+    const group = groups.find((g) => g.provider === 'orcarouter');
+    expect(group).toBeDefined();
+    expect(group!.models.map((m) => m.id)).toContain('orcarouter/auto');
+    expect(hasUsableModel(creds, NO_CUSTOM)).toBe(true);
+  });
+
+  it('orcarouter：空 key → 不可选', () => {
+    const creds: ProviderCredentials = {
+      orcarouter: { authType: 'apiKey', apiKey: '', verified: true },
+    };
+    expect(hasUsableModel(creds, NO_CUSTOM)).toBe(false);
+  });
 });

--- a/lib/providers/usable-models.ts
+++ b/lib/providers/usable-models.ts
@@ -2,6 +2,7 @@ import { getBuiltinModels, type BuiltinProvider } from '@earendil-works/pi-ai/pr
 import type { Api, Model } from '@earendil-works/pi-ai';
 import type { ProviderCredentials, CustomProviderConfig } from '@/lib/persistence/storage';
 import { isCustomProvider, getCustomModels, customProviderKey } from '@/lib/providers/custom-models';
+import { ORCAROUTER_MODELS, ORCAROUTER_PROVIDER } from '@/lib/providers/orcarouter';
 
 /** 一组可选模型：同一 provider 下的全部模型 + 展示用 label。 */
 export interface ModelGroup {
@@ -42,6 +43,11 @@ export function listUsableModelGroups(
     // 自定义的已在上面处理
     if (isCustomProvider(provider)) continue;
     if (seen.has(provider)) continue;
+    if (provider === ORCAROUTER_PROVIDER) {
+      // OrcaRouter's catalog lives in Cebian, not in pi-ai's generated catalog.
+      groups.push({ provider, label: provider, models: ORCAROUTER_MODELS });
+      continue;
+    }
     try {
       const models = getBuiltinModels(provider as BuiltinProvider) as Model<Api>[];
       if (models.length > 0) {


### PR DESCRIPTION
## Summary

Cebian's promise is *"bring your own API key from any model provider"* and its feature table lists **"OpenAI, Anthropic, Google, and any OpenAI-compatible endpoint via custom providers."** That last bucket is where gateway services end up today — but a gateway isn't just an anonymous base URL, it's a provider with its own model namespace and its own routing behavior. OpenRouter already gets first-class treatment in the Settings → "Via API Key" list; this PR gives **OrcaRouter** the same treatment.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means Cebian users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### What changed

- **`lib/providers/registry.ts`** — added `orcarouter` to `APIKEY_PROVIDERS`, so it shows up in Settings → Providers alongside OpenRouter.
- **`lib/providers/orcarouter.ts`** (new) — a small catalog of OrcaRouter's *native auto-routing* models (`orcarouter/auto`, `orcarouter/free`, `orcarouter/fusion`, `orcarouter/fusion-flash`, `orcarouter/fusion-mini`), pointing at `https://api.orcarouter.ai/v1` with the same Cebian attribution headers the OpenRouter integration sends. Vendor-prefixed models (e.g. `deepseek/deepseek-chat`) are intentionally left out — Cebian already ships dedicated providers for those vendors, and OrcaRouter exposes hundreds of them with no per-model metadata to curate against.
- **`lib/providers/resolve-model.ts`** — resolves `orcarouter` from that local catalog (it lives outside pi-ai's generated model catalog), mirroring the existing `openrouter` special case.
- **`lib/providers/usable-models.ts`** — the model selector lists OrcaRouter models once an API key is stored.
- **`components/settings/provider/ProviderApiKeyItem.tsx`** / **`ProviderSummary.tsx`** / **`components/chat/ModelSelector.tsx`** — the API-key connectivity test, provider summary, and model picker all read from the OrcaRouter catalog.

### Why a small static catalog instead of a dynamic fetch

OrcaRouter's `/v1/models` returns 200+ entries with no cost/context metadata, and its unique value is the `orcarouter/*` routing models — those are what this catalog ships. Users can still add any specific `vendor/model` as a custom OpenAI-compatible provider if they want a pinned upstream.

## Testing

- `pnpm run check` passes locally (typecheck + i18n lint + **674 tests**, including new unit tests for the catalog, `resolveModel`, and `listUsableModelGroups`).
- Live-tested the exact runtime path against the real endpoint: `resolveModel({ provider: 'orcarouter', modelId: 'orcarouter/auto' })` → `complete()` from `@earendil-works/pi-ai/compat` (the same call `ProviderApiKeyItem` uses for its connectivity check) returned an `"ok"` completion from OrcaRouter's live API with `maxTokens: 5`. Skipped automatically when no API key is present.
- Verified `orcarouter/auto` passes Cebian's connectivity heuristic (`maxTokens: 5`, expects "ok"), and that OrcaRouter accepts `max_tokens` and the `HTTP-Referer`/`X-Title` attribution headers.

## Related Issues

Closes #64

## Checklist

- [x] `pnpm run check` passes locally
- [x] I have read and agree to the [Cebian CLA](../CLA.md)

---

I'm an engineer on the OrcaRouter team.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter