### PR TITLE
chore: keep OpenAI Codex models current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### 变更 / Changed
 
+- 升级 pi-ai 到 0.85.1，沿用其 OpenAI Codex 上游模型目录，自动纳入 GPT-6 Astra 等最新模型；增加目录回归测试，避免渠道目录更新后应用继续显示旧模型
+
+- Upgraded pi-ai to 0.85.1 so OpenAI Codex uses its upstream model catalog and automatically includes current models such as GPT-6 Astra; added a regression test to catch stale channel catalogs
+
 - 设置页导航从 11 个平行入口收成 3 组 9 项：「连接」（AI 提供商、MCP 服务器）、「定制」（对话、提示词、技能、记忆、页面交互）、「系统」（数据、关于）。原「指引」与「高级」合并为「对话」，原「备份与恢复」与「文件系统」合并为「数据」，各项的具体设置不变。窄屏侧边栏里当前分节的图标会展开显示名称，组与组之间用分隔线区分；宽屏左栏显示分组标题。旧的 `#/instructions`、`#/advanced`、`#/backup`、`#/storage` 链接会自动跳到合并后的新分节
 
 - The Settings navigation collapses 11 flat entries into 3 groups of 9: Connect (AI providers, MCP servers), Customize (Chat, Prompts, Skills, Memory, Page interaction) and System (Data, About). The former Instructions and Advanced sections merge into Chat, and Backup & Restore plus Filesystem merge into Data; every individual setting stays as it was. In the narrow sidepanel the active section's icon expands to show its name and groups are separated by dividers; the wide layout shows group headings in the sidebar. Old `#/instructions`, `#/advanced`, `#/backup` and `#/storage` links redirect to the merged sections
@@ -473,3 +477,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - 首个公开版本
 
 - Initial public release
+

--- a/lib/providers/resolve-model.test.ts
+++ b/lib/providers/resolve-model.test.ts
@@ -60,6 +60,11 @@ describe('resolveModel — custom provider', () => {
 });
 
 describe('resolveModel — built-in provider', () => {
+  it('uses the upstream Codex catalog, including the current GPT-6 model', () => {
+    const ids = (getBuiltinModels('openai-codex') as Model<Api>[]).map((model) => model.id);
+    expect(ids).toContain('gpt-6-astra');
+  });
+
   it('未知内置 provider → null', () => {
     expect(resolveModel({ provider: 'definitely-not-a-provider', modelId: 'x' }, NO_CREDS, NO_CUSTOM)).toBeNull();
   });

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "pnpm": {
     "overrides": {
-      "publish-browser-extension": "6.1.1"
+      "publish-browser-extension": "6.1.1",
+      "@earendil-works/pi-ai": "0.85.1"
     }
   },
   "scripts": {
@@ -43,7 +44,7 @@
     "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.43.11",
     "@earendil-works/pi-agent-core": "^0.84.4",
-    "@earendil-works/pi-ai": "^0.84.4",
+    "@earendil-works/pi-ai": "^0.85.1",
     "@isomorphic-git/lightning-fs": "^4.7.0",
     "@lezer/highlight": "^1.2.3",
     "@mcp-ui/client": "^7.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   publish-browser-extension: 6.1.1
+  '@earendil-works/pi-ai': 0.85.1
 
 importers:
 
@@ -42,8 +43,8 @@ importers:
         specifier: ^0.84.4
         version: 0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
       '@earendil-works/pi-ai':
-        specifier: ^0.84.4
-        version: 0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
+        specifier: 0.85.1
+        version: 0.85.1(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
       '@isomorphic-git/lightning-fs':
         specifier: ^4.7.0
         version: 4.7.0
@@ -238,8 +239,8 @@ packages:
   '@aklinker1/zero-zip@1.0.1':
     resolution: {integrity: sha512-07a596Bd1QO0bi3tIyt2xruq6vKk7hCUt9enHBwggvipB0iiycoJ9/CqzN6UFawaKbOi6NBfMlUxUXzIOZ7Dsg==}
 
-  '@anthropic-ai/sdk@0.91.1':
-    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
+  '@anthropic-ai/sdk@0.123.0':
+    resolution: {integrity: sha512-Y9oX9mPNGZClHQOFqrWRk43Srcu/UHuPq3rfxxOq7JgW0gi+lJA2MAOK4Ul3k/+AUrwRWFJvd0tK3oC0Pw25dw==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -543,13 +544,17 @@ packages:
     resolution: {integrity: sha512-HyUnjaOXj6oN/6SNcr8A1J/ElRQA50FtIE0XUTSKAQVqmdlb9qdojOyUQwF/jULE5+yOEtGuVgi/N1RnBiNG+g==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-ai@0.84.4':
-    resolution: {integrity: sha512-AClAZxf5+c4RRu44NJPS6wyQy+Nmq+Mzyyrdvm4ZVMNuixelO02RZX4G4Aq1F145Yzp43wnM5S+hLlSI7ypfVw==}
+  '@earendil-works/pi-ai@0.85.1':
+    resolution: {integrity: sha512-+VgVIJDkDO2efYJKEEqvPTH4zmnIaXdAppGbO+vKFA9qy5PdhFiAenuFAkU+oiCSfOC4dMHDyrjdQeL4ZoC5CQ==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
   '@earendil-works/pi-telemetry@0.84.4':
     resolution: {integrity: sha512-8e2CuxM+ht+hedQXTZmi5JVl6/xDK9RpSDL2+MbITevKYQhMZ/z6lJOTFgox3HQyGxO8mOZEtYGVeQNaD4OzqA==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-telemetry@0.85.1':
+    resolution: {integrity: sha512-Bg/YN6kA7Swja/NQxka8xFdecb4E/auIEGF2G5A25EaQXhRnPj300/7/KpgsDDMYUzHTDAv4RyUxaQPJKW81Rw==}
     engines: {node: '>=22.19.0'}
 
   '@esbuild/aix-ppc64@0.28.1':
@@ -2214,6 +2219,9 @@ packages:
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -3325,6 +3333,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-text-encoding@1.0.6:
     resolution: {integrity: sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==}
@@ -5157,6 +5168,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.1.1:
+    resolution: {integrity: sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -5823,9 +5837,10 @@ snapshots:
 
   '@aklinker1/zero-zip@1.0.1': {}
 
-  '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.123.0(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.1.1
     optionalDependencies:
       zod: 4.4.3
 
@@ -6375,7 +6390,7 @@ snapshots:
 
   '@earendil-works/pi-agent-core@0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.85.1(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
       '@earendil-works/pi-telemetry': 0.84.4
       diff: 8.0.4
       ignore: 7.0.5
@@ -6389,11 +6404,11 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.85.1(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)':
     dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@anthropic-ai/sdk': 0.123.0(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
-      '@earendil-works/pi-telemetry': 0.84.4
+      '@earendil-works/pi-telemetry': 0.85.1
       '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))
       '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2
@@ -6410,6 +6425,8 @@ snapshots:
       - zod
 
   '@earendil-works/pi-telemetry@0.84.4': {}
+
+  '@earendil-works/pi-telemetry@0.85.1': {}
 
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
@@ -7972,6 +7989,8 @@ snapshots:
       '@smithy/util-buffer-from': 2.2.0
       tslib: 2.8.1
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tailwindcss/node@4.3.3':
@@ -9130,6 +9149,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-sha256@1.3.0: {}
 
   fast-text-encoding@1.0.6: {}
 
@@ -11317,6 +11338,11 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
+
+  standardwebhooks@1.1.1:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
 
   statuses@2.0.2: {}
 


### PR DESCRIPTION
## What changed

Cebian gets built-in provider models from `@earendil-works/pi-ai/providers/all`, via `getBuiltinModels('openai-codex')`. The catalog is packaged by pi-ai; Cebian does not fetch or hard-code the Codex model list itself.

This updates pi-ai to 0.85.1 and pins the transitive copy to the same version so the provider catalog includes `gpt-6-astra` without maintaining a second model source. A regression test verifies the current GPT-6 Codex entry is visible through Cebian's resolver.

## Validation

- `pnpm vitest run lib/providers/resolve-model.test.ts`
- `pnpm check`
